### PR TITLE
feat: デモ用スタンプ取得機能とデバッグモード対応を実装

### DIFF
--- a/lib/data/spots.dart
+++ b/lib/data/spots.dart
@@ -1,6 +1,33 @@
 import '../models/spot.dart';
 
 const List<Spot> spots = [
+  // === デモスポット（距離判定なしでテスト可能） ===
+  Spot(
+    title: '【デモ】サンプル花畑',
+    location: 'デモ用スポット（どこからでも取得可能）',
+    image: 'assets/images/flower_field.png',
+    description: 'これはデモ用のスポットです。位置情報に関係なく、どこからでもスタンプを取得できます。実際のアプリでは、スポットの近くに行く必要があります。',
+    touristTitle: 'デモ観光情報',
+    touristLocation: 'デモ用観光スポット',
+    touristDescription: 'デモ用の観光情報です。実際のアプリでは、ここに本物の観光情報が表示されます。',
+    latitude: 37.9026, // 新潟県の中心部
+    longitude: 139.0232,
+    isDemo: true, // デモスポットフラグ
+  ),
+  Spot(
+    title: '【デモ】テスト桜スポット',
+    location: 'デモ用桜スポット（距離判定なし）',
+    image: 'assets/images/cherryblossom.png',
+    description: 'デモ用の桜スポットです。スタンプ取得のテストに使用できます。実際の運用では位置情報による制限があります。',
+    touristTitle: 'デモ桜観光地',
+    touristLocation: 'デモ用桜の名所',
+    touristDescription: 'デモ用の桜観光情報です。',
+    latitude: 37.8500,
+    longitude: 139.1000,
+    isDemo: true, // デモスポットフラグ
+  ),
+  
+  // === 実際のスポット ===
   Spot(
     title: '五泉市チューリップまつり',
     location: '五泉市栗本地区一本杉内',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:provider/provider.dart';
+import 'package:geolocator_platform_interface/geolocator_platform_interface.dart';
+import 'package:geolocator/geolocator.dart';
 import 'firebase_options.dart';
 import 'providers/stamp_provider.dart';
 import 'screens/home_screen.dart';
@@ -15,9 +18,78 @@ import 'screens/profileedit_screen.dart';
 import 'screens/stamps_collection_screen.dart';
 import 'screens/unity_ar_screen.dart';
 
+// デモ設定クラス
+class _DemoConfig {
+  static const demoMode = bool.fromEnvironment('DEMO', defaultValue: false);
+}
+
+// 偽装位置情報クラス（テスト用）
+class FakeGeolocatorPlatform extends GeolocatorPlatform {
+  final Position _fakePosition;
+  
+  FakeGeolocatorPlatform(this._fakePosition);
+
+  @override
+  Future<Position> getCurrentPosition({
+    LocationSettings? locationSettings,
+  }) async {
+    return _fakePosition;
+  }
+
+  @override
+  Future<LocationPermission> checkPermission() async {
+    return LocationPermission.always;
+  }
+
+  @override
+  Future<LocationPermission> requestPermission() async {
+    return LocationPermission.always;
+  }
+
+  @override
+  Future<bool> isLocationServiceEnabled() async {
+    return true;
+  }
+
+  @override
+  double distanceBetween(
+    double startLatitude,
+    double startLongitude,
+    double endLatitude,
+    double endLongitude,
+  ) {
+    return Geolocator.distanceBetween(
+      startLatitude,
+      startLongitude,
+      endLatitude,
+      endLongitude,
+    );
+  }
+}
+
 Future<void> main() async {
   try {
     WidgetsFlutterBinding.ensureInitialized();
+    
+    // デモモードでのジオロケーション偽装設定
+    if (kDebugMode && _DemoConfig.demoMode) {
+      // 新潟県の中心付近を偽装位置として設定
+      final fakePosition = Position(
+        latitude: 37.9026,
+        longitude: 139.0232,
+        timestamp: DateTime.now(),
+        accuracy: 5.0,
+        altitude: 0.0,
+        heading: 0.0,
+        speed: 0.0,
+        speedAccuracy: 0.0,
+        altitudeAccuracy: 0.0,
+        headingAccuracy: 0.0,
+      );
+      
+      GeolocatorPlatform.instance = FakeGeolocatorPlatform(fakePosition);
+      print('🧪 デモモード: 偽装位置情報を設定しました (${fakePosition.latitude}, ${fakePosition.longitude})');
+    }
     
     // Initialize Firebase
     await Firebase.initializeApp(
@@ -44,30 +116,30 @@ class NiigataFlowerGuide extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => StampProvider()),
       ],
       child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        title: 'Niigata 花図鑑',
-        theme: ThemeData(
-          scaffoldBackgroundColor: const Color(0xFFf4efe1),
-          colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF3E5C40)),
-          useMaterial3: true,
-        ),
-        builder: (context, child) {
-          return MediaQuery(
-            data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
-            child: child!,
-          );
-        },
-        initialRoute: '/login',
-        routes: {
-          '/login': (context) => const LoginScreen(),
-          '/signup': (context) => const SignupScreen(),
-          '/': (context) => const HomeScreen(),
-          '/map': (context) => const MapScreen(),
-          '/profile': (context) => const ProfileScreen(),
-          '/profileedit': (context) => const ProfileEditScreen(),
-          '/collection': (context) => const StampCollectionScreen(),
-          '/ar': (context) => const UnityArScreen(),
-        },
+      debugShowCheckedModeBanner: false,
+      title: 'Niigata 花図鑑',
+      theme: ThemeData(
+        scaffoldBackgroundColor: const Color(0xFFf4efe1),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF3E5C40)),
+        useMaterial3: true,
+      ),
+      builder: (context, child) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
+          child: child!,
+        );
+      },
+      initialRoute: '/login',
+      routes: {
+        '/login': (context) => const LoginScreen(),
+        '/signup': (context) => const SignupScreen(),
+        '/': (context) => const HomeScreen(),
+        '/map': (context) => const MapScreen(),
+        '/profile': (context) => const ProfileScreen(),
+        '/profileedit': (context) => const ProfileEditScreen(),
+        '/collection': (context) => const StampCollectionScreen(),
+        '/ar': (context) => const UnityArScreen(),
+      },
       ),
     );
   }

--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -8,6 +8,7 @@ class Spot {
   final String touristDescription;
   final double latitude;
   final double longitude;
+  final bool isDemo; // デモスポットかどうかを識別
 
   const Spot({
     required this.title,
@@ -19,6 +20,7 @@ class Spot {
     required this.touristDescription,
     required this.latitude,
     required this.longitude,
+    this.isDemo = false, // デフォルトはfalse
   });
 
   factory Spot.fromMap(Map<String, dynamic> map) {
@@ -32,6 +34,7 @@ class Spot {
       touristDescription: map['tourist_description'] ?? '',
       latitude: map['latitude'] ?? 0.0,
       longitude: map['longitude'] ?? 0.0,
+      isDemo: map['isDemo'] ?? false,
     );
   }
 } 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -12,35 +12,35 @@ class HomeScreen extends StatelessWidget {
       backgroundColor: Colors.transparent,
       body: SafeArea(
         child: SingleChildScrollView(
-          child: Column(
-            children: [
-              const SizedBox(height: 16),
-              // 画像部分を高さ 120 にダウン
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(16),
-                  child: Container(
-                    color: const Color(0xFF3E5C40),
-                    child: Image.asset(
-                      'assets/images/flower_field.png',
-                      width: double.infinity,
-                      height: 120,
-                      fit: BoxFit.cover,
-                    ),
+        child: Column(
+          children: [
+            const SizedBox(height: 16),
+            // 画像部分を高さ 120 にダウン
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Container(
+                  color: const Color(0xFF3E5C40),
+                  child: Image.asset(
+                    'assets/images/flower_field.png',
+                    width: double.infinity,
+                    height: 120,
+                    fit: BoxFit.cover,
                   ),
                 ),
               ),
-              const SizedBox(height: 12),
-              // タイトル
-              Text(
-                'Niigata 花図鑑',
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      color: const Color(0xFF3E5C40),
-                      fontWeight: FontWeight.bold,
-                    ),
-              ),
-              const SizedBox(height: 16),
+            ),
+            const SizedBox(height: 12),
+            // タイトル
+            Text(
+              'Niigata 花図鑑',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    color: const Color(0xFF3E5C40),
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 16),
               // グリッド
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -99,7 +99,7 @@ class HomeScreen extends StatelessWidget {
                 child: const NearbySpotsWidget(),
               ),
               const SizedBox(height: 16),
-            ],
+          ],
           ),
         ),
       ),

--- a/lib/screens/stamps_collection_screen.dart
+++ b/lib/screens/stamps_collection_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/stamp_provider.dart';
 import '../models/stamp.dart';
+import '../data/spots.dart';
 
 /// スタンプコレクション画面のウィジェット
 class StampCollectionScreen extends StatelessWidget {
@@ -139,22 +140,22 @@ class StampCollectionScreen extends StatelessWidget {
                       }
 
                       return Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: GridView.builder(
-                          itemCount: stamps.length,
-                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 3,
-                            crossAxisSpacing: 12,
-                            mainAxisSpacing: 12,
-                            childAspectRatio: 1,
-                          ),
-                          itemBuilder: (context, index) {
-                            final stamp = stamps[index];
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: GridView.builder(
+                      itemCount: stamps.length,
+                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3,
+                        crossAxisSpacing: 12,
+                        mainAxisSpacing: 12,
+                        childAspectRatio: 1,
+                      ),
+                      itemBuilder: (context, index) {
+                        final stamp = stamps[index];
                             return GestureDetector(
                               onTap: () => _showStampDetail(context, stamp),
                               child: Container(
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
                                   border: Border.all(
                                     color: Colors.green,
                                     width: 3,
@@ -166,11 +167,11 @@ class StampCollectionScreen extends StatelessWidget {
                                       offset: const Offset(0, 2),
                                     ),
                                   ],
-                                ),
-                                child: ClipOval(
-                                  child: Image.asset(
+                          ),
+                          child: ClipOval(
+                            child: Image.asset(
                                     stamp.spotImage,
-                                    fit: BoxFit.cover,
+                              fit: BoxFit.cover,
                                     errorBuilder: (context, error, stackTrace) {
                                       return Container(
                                         color: Colors.green.shade100,
@@ -178,12 +179,12 @@ class StampCollectionScreen extends StatelessWidget {
                                           Icons.star,
                                           size: 40,
                                           color: Colors.green.shade600,
-                                        ),
-                                      );
-                                    },
-                                  ),
-                                ),
-                              ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ),
                             );
                           },
                         ),
@@ -195,19 +196,23 @@ class StampCollectionScreen extends StatelessWidget {
                 // 進捗表示とボトムナビゲーション
                 Consumer<StampProvider>(
                   builder: (context, stampProvider, child) {
-                    final total = 5; // 全スポット数（data/spots.dartから取得可能）
-                    final collectedCount = stampProvider.stampCount;
+                    // 実際のスポット数（デモスポット除外）
+                    final total = spots.where((spot) => !spot.isDemo).length;
+                    final collectedCount = stampProvider.stamps
+                        .where((stamp) => !spots.any((spot) => 
+                            spot.isDemo && spot.title == stamp.spotTitle))
+                        .length;
 
                     return Column(
                       children: [
-                        // 進捗バー
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
+                // 進捗バー
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
                           child: Column(
                             children: [
                               Row(
                                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                children: [
+                    children: [
                                   Text(
                                     '取得済み: $collectedCount / $total',
                                     style: const TextStyle(
@@ -226,43 +231,43 @@ class StampCollectionScreen extends StatelessWidget {
                               ),
                               const SizedBox(height: 8),
                               LinearProgressIndicator(
-                                value: collectedCount / total,
-                                backgroundColor: Colors.green.shade100,
-                                color: Colors.green,
-                                minHeight: 8,
-                              ),
-                            ],
-                          ),
-                        ),
+                          value: collectedCount / total,
+                          backgroundColor: Colors.green.shade100,
+                          color: Colors.green,
+                          minHeight: 8,
+                      ),
+                    ],
+                  ),
+                ),
 
-                        // ボトムナビゲーション
-                        BottomNavigationBar(
-                          type: BottomNavigationBarType.fixed,
-                          currentIndex: 3,
+                // ボトムナビゲーション
+                BottomNavigationBar(
+                  type: BottomNavigationBarType.fixed,
+                  currentIndex: 3,
                           selectedItemColor: Colors.green,
                           unselectedItemColor: Colors.grey,
-                          items: const [
-                            BottomNavigationBarItem(icon: Icon(Icons.home), label: 'ホーム'),
-                            BottomNavigationBarItem(icon: Icon(Icons.map), label: 'マップ'),
-                            BottomNavigationBarItem(icon: Icon(Icons.camera_alt), label: 'ARカメラ'),
-                            BottomNavigationBarItem(icon: Icon(Icons.collections), label: 'コレクション'),
-                            BottomNavigationBarItem(icon: Icon(Icons.person), label: 'プロフィール'),
-                          ],
-                          onTap: (index) {
-                            switch (index) {
-                              case 0:
-                                Navigator.pushNamed(context, '/');
-                                break;
-                              case 1:
-                                Navigator.pushNamed(context, '/map');
-                                break;
-                              case 2:
-                                Navigator.pushNamed(context, '/ar');
-                                break;
-                              case 4:
-                                Navigator.pushNamed(context, '/profile');
-                                break;
-                            }
+                  items: const [
+                    BottomNavigationBarItem(icon: Icon(Icons.home), label: 'ホーム'),
+                    BottomNavigationBarItem(icon: Icon(Icons.map), label: 'マップ'),
+                    BottomNavigationBarItem(icon: Icon(Icons.camera_alt), label: 'ARカメラ'),
+                    BottomNavigationBarItem(icon: Icon(Icons.collections), label: 'コレクション'),
+                    BottomNavigationBarItem(icon: Icon(Icons.person), label: 'プロフィール'),
+                  ],
+                  onTap: (index) {
+                    switch (index) {
+                      case 0:
+                        Navigator.pushNamed(context, '/');
+                        break;
+                      case 1:
+                        Navigator.pushNamed(context, '/map');
+                        break;
+                      case 2:
+                        Navigator.pushNamed(context, '/ar');
+                        break;
+                      case 4:
+                        Navigator.pushNamed(context, '/profile');
+                        break;
+                    }
                           },
                         ),
                       ],
@@ -318,13 +323,29 @@ class StampCollectionScreen extends StatelessWidget {
                 const SizedBox(height: 16),
                 
                 // スポット情報
-                Text(
-                  stamp.spotTitle,
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                  ),
-                  textAlign: TextAlign.center,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // デモスポット判定
+                    if (spots.any((spot) => spot.isDemo && spot.title == stamp.spotTitle)) ...[
+                      Icon(
+                        Icons.science,
+                        size: 20,
+                        color: Colors.orange[700],
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                    Flexible(
+                      child: Text(
+                        stamp.spotTitle,
+                        style: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 8),
                 Text(

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,5 +1,12 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:geolocator/geolocator.dart';
 import '../models/spot.dart';
+
+// デモ設定クラス
+class _DemoConfig {
+  // dart-define で上書き可: flutter run -d chrome --dart-define=DEMO=true
+  static const demoMode = bool.fromEnvironment('DEMO', defaultValue: false);
+}
 
 class LocationService {
   static const double _stampCollectionRadius = 100.0; // メートル
@@ -65,6 +72,11 @@ class LocationService {
 
   // ユーザーがスポットの近くにいるかチェック
   static Future<bool> isNearSpot(Spot spot) async {
+    // デモスポット または デバッグモードでは常にtrue
+    if (spot.isDemo || (kDebugMode && _DemoConfig.demoMode)) {
+      return true;
+    }
+
     Position? currentPosition = await getCurrentPosition();
     if (currentPosition == null) {
       return false;
@@ -119,13 +131,24 @@ class LocationService {
   static Future<List<Map<String, dynamic>>> getSpotsWithinRange(
       List<Spot> spots) async {
     Position? currentPosition = await getCurrentPosition();
-    if (currentPosition == null) {
-      return [];
-    }
-
+    
     List<Map<String, dynamic>> nearbySpots = [];
 
     for (Spot spot in spots) {
+      // デモスポット または デバッグモードの場合
+      if (spot.isDemo || (kDebugMode && _DemoConfig.demoMode)) {
+        nearbySpots.add({
+          'spot': spot,
+          'distance': 0.0, // デモスポットは距離0として扱う
+        });
+        continue;
+      }
+
+      // 通常の距離判定
+      if (currentPosition == null) {
+        continue;
+      }
+
       double distance = calculateDistance(
         currentPosition.latitude,
         currentPosition.longitude,
@@ -141,7 +164,7 @@ class LocationService {
       }
     }
 
-    // 距離でソート
+    // 距離でソート（デモスポットが最初に来る）
     nearbySpots.sort((a, b) => (a['distance'] as double).compareTo(b['distance'] as double));
 
     return nearbySpots;

--- a/lib/widgets/nearby_spots_widget.dart
+++ b/lib/widgets/nearby_spots_widget.dart
@@ -122,11 +122,15 @@ class _NearbySpotsWidgetState extends State<NearbySpotsWidget> {
                     margin: const EdgeInsets.only(bottom: 12),
                     decoration: BoxDecoration(
                       border: Border.all(
-                        color: isCollected ? Colors.grey[300]! : Colors.green[300]!,
+                        color: spot.isDemo 
+                            ? Colors.orange[300]! 
+                            : (isCollected ? Colors.grey[300]! : Colors.green[300]!),
                         width: 2,
                       ),
                       borderRadius: BorderRadius.circular(12),
-                      color: isCollected ? Colors.grey[50] : Colors.green[50],
+                      color: spot.isDemo 
+                          ? Colors.orange[50] 
+                          : (isCollected ? Colors.grey[50] : Colors.green[50]),
                     ),
                     child: Padding(
                       padding: const EdgeInsets.all(12.0),
@@ -139,12 +143,26 @@ class _NearbySpotsWidgetState extends State<NearbySpotsWidget> {
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
-                                    Text(
-                                      spot.title,
-                                      style: const TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.bold,
-                                      ),
+                                    Row(
+                                      children: [
+                                        if (spot.isDemo) ...[
+                                          Icon(
+                                            Icons.science,
+                                            size: 16,
+                                            color: Colors.orange[700],
+                                          ),
+                                          const SizedBox(width: 4),
+                                        ],
+                                        Expanded(
+                                          child: Text(
+                                            spot.title,
+                                            style: const TextStyle(
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
                                     ),
                                     const SizedBox(height: 4),
                                     Text(
@@ -163,20 +181,26 @@ class _NearbySpotsWidgetState extends State<NearbySpotsWidget> {
                                   vertical: 4,
                                 ),
                                 decoration: BoxDecoration(
-                                  color: isCollected ? Colors.grey : Colors.green,
+                                  color: spot.isDemo 
+                                      ? Colors.orange 
+                                      : (isCollected ? Colors.grey : Colors.green),
                                   borderRadius: BorderRadius.circular(12),
                                 ),
                                 child: Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
                                     Icon(
-                                      isCollected ? Icons.check : Icons.location_on,
+                                      spot.isDemo 
+                                          ? Icons.science
+                                          : (isCollected ? Icons.check : Icons.location_on),
                                       size: 14,
                                       color: Colors.white,
                                     ),
                                     const SizedBox(width: 4),
                                     Text(
-                                      isCollected ? '取得済み' : '${distance.round()}m',
+                                      spot.isDemo 
+                                          ? 'デモ'
+                                          : (isCollected ? '取得済み' : '${distance.round()}m'),
                                       style: const TextStyle(
                                         fontSize: 12,
                                         fontWeight: FontWeight.bold,

--- a/lib/widgets/stamp_collection_button.dart
+++ b/lib/widgets/stamp_collection_button.dart
@@ -216,6 +216,10 @@ class StampCollectionButton extends StatelessWidget {
       return const Icon(Icons.check_circle);
     }
 
+    if (spot.isDemo) {
+      return const Icon(Icons.science);
+    }
+
     if (!isInRange) {
       return const Icon(Icons.location_off);
     }
@@ -229,6 +233,10 @@ class StampCollectionButton extends StatelessWidget {
       return '取得済み';
     }
 
+    if (spot.isDemo) {
+      return 'デモスタンプを取得';
+    }
+
     if (!isInRange) {
       return 'スポットに近づいてください';
     }
@@ -240,6 +248,10 @@ class StampCollectionButton extends StatelessWidget {
   Color _getButtonColor(bool isCollected, bool isInRange) {
     if (isCollected) {
       return Colors.grey;
+    }
+
+    if (spot.isDemo) {
+      return Colors.orange;
     }
 
     if (!isInRange) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,7 +289,7 @@ packages:
     source: hosted
     version: "0.2.3"
   geolocator_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: geolocator_platform_interface
       sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   firebase_auth: ^5.6.2
   cloud_firestore: ^5.6.11
   geolocator: ^14.0.2
+  geolocator_platform_interface: ^4.2.4
   provider: ^6.0.5
   # flutter_unity_widget: ^2022.2.0
 


### PR DESCRIPTION
## 概要
<!-- この PR の目的や背景を簡潔に記載してください -->
- デモ・テスト用のスタンプ取得機能を実装
- 位置情報に依存しないデモスポットシステムを構築
- 開発・動作確認時の利便性を大幅に向上
- 本番環境への影響を最小限に抑えた安全な実装

## 🛠️ 変更内容
<!-- 何をどう変更したかを箇条書きで -->

### 新規作成
- デモ設定クラス `_DemoConfig` - dart-defineによるデモモード制御
- `FakeGeolocatorPlatform` - テスト用位置情報モッククラス
- デモスポット2種類 - 「【デモ】サンプル花畑」「【デモ】テスト桜スポット」

### 修正・更新
- `lib/models/spot.dart` - `isDemo`フィールドの追加
- `lib/services/location_service.dart` - 距離判定バイパスロジックの実装
- `lib/data/spots.dart` - デモスポットデータの追加
- `lib/widgets/nearby_spots_widget.dart` - デモスポット識別UI（オレンジ色、実験アイコン）
- `lib/widgets/stamp_collection_button.dart` - デモ専用ボタンテキスト・アイコン対応
- `lib/screens/stamps_collection_screen.dart` - デモスポット除外統計計算
- `lib/main.dart` - デバッグ時の位置情報モック設定
- `pubspec.yaml` - `geolocator_platform_interface` 依存関係追加

## 🔧 技術的詳細
- **デモモード制御**: `bool.fromEnvironment('DEMO')`によるコンパイル時フラグ
- **距離判定バイパス**: `spot.isDemo || (kDebugMode && _DemoConfig.demoMode)`
- **位置情報モック**: `GeolocatorPlatform.instance`の差し替えによる偽装
- **UI識別**: デモスポットはオレンジ色背景、実験アイコン、「デモ」バッジで表示
- **統計計算**: デモスポットを除外した正確な進捗率計算

## 🎮 使用方法

### 通常モード（デモスポットのみ距離判定なし）
```bash
flutter run -d chrome
```

### 完全デモモード（全スポット距離判定なし）
```bash
flutter run -d chrome --dart-define=DEMO=true
```

## 🔒 セキュリティ・本番環境への配慮
- `kDebugMode`によりリリースビルドでは自動的に無効化
- デモスポットは明確に識別可能な表示で事故防止
- 既存のFirestoreセキュリティルールと完全互換
- 本番データとデモデータの明確な分離

## ✅ 動作確認手順
1. リポジトリをクローン＆チェックアウト  
   ```bash
   git fetch origin feature/feature#20
   git checkout feature/feature#20
   ```

2. 依存関係のインストール
   ```bash
   flutter pub get
   ```

3. 通常モードでのテスト
   ```bash
   flutter run -d chrome
   ```
   - デモスポットがオレンジ色で表示されることを確認
   - デモスポットのスタンプが位置に関係なく取得できることを確認

4. 完全デモモードでのテスト
   ```bash
   flutter run -d chrome --dart-define=DEMO=true
   ```
   - コンソールに「🧪 デモモード: 偽装位置情報を設定しました」が表示されることを確認
   - すべてのスポットが取得可能になることを確認

5. 機能テスト
   - ホーム画面でデモスポットが「デモ」バッジ付きで表示
   - マップ画面でデモスポット詳細に「デモスタンプを取得」ボタン表示
   - コレクション画面でデモスタンプに実験アイコン表示
   - 統計にデモスポットが含まれないことを確認

## 🎯 実装された機能
- ✅ デモスポット機能（位置判定バイパス）
- ✅ デバッグモード対応（dart-define制御）
- ✅ 位置情報モック機能（テスト用）
- ✅ デモスポット専用UI（オレンジ色、実験アイコン）
- ✅ 統計計算の正確性向上（デモ除外）
- ✅ 本番環境への安全性確保（kDebugMode制御）

## 💡 今後の拡張予定
- Firebase Remote Configによるリモートデモモード制御
- Flutter Flavorsによるdemo/prodビルド完全分離
- より詳細なデモシナリオの追加
- 自動テスト用の位置情報モックシステム拡張

## 📝 関連 Issue / PR
- Issue #20: スタンプ取得機能のデモ・テスト環境整備
- 前PR: スタンプ取得機能基盤実装からの発展