### PR TITLE
feat: スポット詳細画面の大幅刷新とデータモデル拡張

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,106 @@
 - 教育機関
 - 地域住民
 
+## アーキテクチャ
+
+### データ管理戦略
+
+#### 現在の実装（ローカル JSON）
+- スポット数: 8件
+- データ管理: `lib/data/spots.dart`
+- 利点: 完全無料、高速、オフライン対応
+
+#### Firestore移行時の料金試算
+
+スポット数が30件を超えた場合のCloud Firestore移行時の料金試算：
+
+##### 想定利用パターン
+- 月間アクティブユーザー: 1,000人
+- 1人あたり平均セッション: 5回/月
+- 1セッションあたり平均スポット閲覧: 3件
+- 1スポットあたり平均スタンプ取得: 0.5件/セッション
+
+##### 読み込み操作
+```
+月間読み込み = 1,000人 × 5セッション × 3スポット = 15,000 reads/月
+```
+
+##### 書き込み操作
+```
+月間書き込み = 1,000人 × 5セッション × 0.5スタンプ = 2,500 writes/月
+```
+
+##### 料金計算（2024年12月時点）
+- 読み込み: 15,000 reads × $0.06/100,000 = $0.009/月
+- 書き込み: 2,500 writes × $0.18/100,000 = $0.0045/月
+- 合計: 約$0.014/月（約2円/月）
+
+##### 無料枠との比較
+- 読み込み無料枠: 50,000 reads/月 → 余裕あり
+- 書き込み無料枠: 20,000 writes/月 → 余裕あり
+- 削除無料枠: 20,000 deletes/月 → 余裕あり
+
+**結論**: 現在の利用想定では、Firestore移行後も無料枠内で運用可能
+
+#### 課金抑制戦略
+
+1. **ページング実装**
+   ```dart
+   // 一度に取得するスポット数を制限
+   Query query = spots.limit(10);
+   ```
+
+2. **キャッシュ活用**
+   ```dart
+   // オフライン持続性を有効化
+   FirebaseFirestore.instance.settings = Settings(
+     persistenceEnabled: true,
+     cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+   );
+   ```
+
+3. **条件付きクエリ**
+   ```dart
+   // 位置情報に基づく範囲クエリ
+   Query query = spots.where('latitude', isGreaterThan: minLat)
+                     .where('latitude', isLessThan: maxLat);
+   ```
+
+## 開発環境
+
+- Flutter SDK: 3.8.1+
+- Dart: 3.8.1+
+- Firebase: 最新版
+
+## セットアップ
+
+1. 依存関係をインストール
+```bash
+flutter pub get
+```
+
+2. Firebase設定
+```bash
+# Firebase CLIでプロジェクトを設定
+firebase login
+firebase init
+```
+
+3. アプリを起動
+```bash
+flutter run
+```
+
+## 使用技術
+
+- Flutter/Dart
+- Firebase Authentication
+- Cloud Firestore
+- Google Maps API
+- Provider (状態管理)
+- Geolocator (位置情報)
+
+## ライセンス
+
+このプロジェクトはMITライセンスの下で公開されています。
+

--- a/lib/data/spots.dart
+++ b/lib/data/spots.dart
@@ -3,6 +3,7 @@ import '../models/spot.dart';
 const List<Spot> spots = [
   // === デモスポット（距離判定なしでテスト可能） ===
   Spot(
+    id: 'demo-001',
     title: '【デモ】サンプル花畑',
     location: 'デモ用スポット（どこからでも取得可能）',
     image: 'assets/images/flower_field.png',
@@ -13,8 +14,22 @@ const List<Spot> spots = [
     latitude: 37.9026, // 新潟県の中心部
     longitude: 139.0232,
     isDemo: true, // デモスポットフラグ
+    flowerInfo: FlowerInfo(
+      scientificName: 'Tulipa gesneriana',
+      bloomPeriod: '4-5月',
+      bestViewingTime: '4月中旬',
+      flowerLanguage: '思いやり',
+      referenceUrl: 'https://ja.wikipedia.org/wiki/チューリップ',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: 'デモ用観光地、サンプル公園、テスト博物館',
+      accessInfo: 'JR新潟駅からバスで30分、デモ停留所下車',
+      facilities: '駐車場あり、トイレあり、売店あり',
+      websiteUrl: 'https://example.com/demo',
+    ),
   ),
   Spot(
+    id: 'demo-002',
     title: '【デモ】テスト桜スポット',
     location: 'デモ用桜スポット（距離判定なし）',
     image: 'assets/images/cherryblossom.png',
@@ -25,10 +40,23 @@ const List<Spot> spots = [
     latitude: 37.8500,
     longitude: 139.1000,
     isDemo: true, // デモスポットフラグ
+    flowerInfo: FlowerInfo(
+      scientificName: 'Prunus × yedoensis',
+      bloomPeriod: '4-5月',
+      bestViewingTime: '4月上旬',
+      flowerLanguage: '精神美',
+      referenceUrl: 'https://ja.wikipedia.org/wiki/ソメイヨシノ',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: 'デモ桜公園、テスト神社、サンプル美術館',
+      accessInfo: 'JR新潟駅からバスで20分、デモ桜前停留所下車',
+      facilities: '駐車場あり、トイレあり、ベンチあり',
+    ),
   ),
   
   // === 実際のスポット ===
   Spot(
+    id: 'gosen-tulip-001',
     title: '五泉市チューリップまつり',
     location: '五泉市栗本地区一本杉内',
     image: 'assets/images/tulip_field.jpg',
@@ -38,8 +66,22 @@ const List<Spot> spots = [
     touristDescription: 'ラポルテ五泉は、約2万4,000㎡の敷地に床面積3,700㎡の建物と3つの広場をもつ五泉市の交流拠点複合施設です。  館内には、芸術や学びの場となる多目的ホールや多目的室。市が日本に誇るニットや絹産業、地元の特産物を販売する産直ショップ＆カフェテリア。特におすすめなのは、木造建築を生かして面白遊具を備えた「子どもの遊び場」や開放感あるガレリアの空間です。  約 160 台収容できる駐車場と夜間にも利用できる24時間トイレも備えて車の利用者にも便利です。  "まるっと1日楽しく過ごせる"ラポルテ五泉 みなさまのご利用を、心からお待ちしております。',
     latitude: 37.753417,
     longitude: 139.192861,
+    flowerInfo: FlowerInfo(
+      scientificName: 'Tulipa gesneriana',
+      bloomPeriod: '4-5月',
+      bestViewingTime: '4月下旬',
+      flowerLanguage: '思いやり',
+      referenceUrl: 'https://www.city.gosen.lg.jp/soshiki/7/1/1/1/1578.html',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: 'ラポルテ五泉、東公園、五泉市村松郷土資料館',
+      accessInfo: 'JR五泉駅からバスで15分、チューリップまつり会場下車',
+      facilities: '駐車場あり、トイレあり、売店あり',
+      websiteUrl: 'https://www.city.gosen.lg.jp/',
+    ),
   ),
   Spot(
+    id: 'niigata-sakura-001',
     title: '新潟市桜まつり',
     location: '新潟市中央区白山公園',
     image: 'assets/images/cherryblossom.png',
@@ -49,6 +91,18 @@ const List<Spot> spots = [
     touristDescription: '新潟市の歴史と文化を学べる博物館です。常設展では新潟の歴史を紹介し、特別展も定期的に開催されています。',
     latitude: 37.91444659509614,
     longitude:  139.0393600507152,
+    flowerInfo: FlowerInfo(
+      scientificName: 'Prunus × yedoensis',
+      bloomPeriod: '4-5月',
+      bestViewingTime: '4月上旬',
+      flowerLanguage: '精神美',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: '新潟市歴史博物館、白山神社、信濃川やすらぎ堤',
+      accessInfo: 'JR新潟駅からバスで10分、白山公園前下車',
+      facilities: '駐車場あり、トイレあり、売店あり',
+      websiteUrl: 'https://www.city.niigata.lg.jp/',
+    ),
   ),
   // Spot(
   //   title: '上越市コスモス畑',
@@ -73,6 +127,7 @@ const List<Spot> spots = [
   //   longitude: 138.88193010907332,
   // ),
   Spot(
+    id: 'fukushimagata-001',
     title: '福島潟 菜の花畑',
     location: '新潟市北区前新田乙493（福島潟）',
     image: 'assets/images/flower_field.png',
@@ -82,6 +137,18 @@ const List<Spot> spots = [
     touristDescription: 'ビュー福島潟は、潟の自然や歴史を学べる展示や展望ホール、カフェ、ミュージアムショップを備えた情報発信施設です。高さ29mの屋上からは潟と越後平野を一望できます。',
     latitude: 37.91067636357914,
     longitude: 139.2482891677142,
+    flowerInfo: FlowerInfo(
+      scientificName: 'Brassica rapa',
+      bloomPeriod: '4-5月',
+      bestViewingTime: '4月中旬',
+      flowerLanguage: '快活',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: '水の駅「ビュー福島潟」、福島潟遊歩道、五頭連峰',
+      accessInfo: 'JR新潟駅からバスで30分、福島潟前下車',
+      facilities: '駐車場あり、トイレあり、売店あり、レストランあり',
+      websiteUrl: 'https://www.city.niigata.lg.jp/kurashi/park/shoukai/area/kita_ku/p_fukushima.html',
+    ),
   ),
   // Spot(
   //   title: '三条市ユリ園',
@@ -95,6 +162,7 @@ const List<Spot> spots = [
   //   longitude: 138.9559,
   // ),
   Spot(
+    id: 'botanical-garden-001',
     title: '新潟県立植物園 ハスの花',
     location: '新潟市秋葉区金津186（新潟県立植物園）',
     image: 'assets/images/flower_field.png',
@@ -104,8 +172,21 @@ const List<Spot> spots = [
     touristDescription: '新潟県立植物園は、高さ30mの熱帯植物ドームや花と緑のステージ、水生植物園などを備えた県内最大級の植物園です。季節ごとの企画展示や体験イベントも開催され、家族連れにも人気のスポットです。',
     latitude: 37.760635957307656, 
     longitude: 139.1122557955988,
+    flowerInfo: FlowerInfo(
+      scientificName: 'Nelumbo nucifera',
+      bloomPeriod: '7-8月',
+      bestViewingTime: '7月上旬',
+      flowerLanguage: '清らかな心',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: '新潟県立植物園、秋葉公園、中野邸記念館',
+      accessInfo: 'JR新津駅からバスで10分、県立植物園前下車',
+      facilities: '駐車場あり、トイレあり、レストランあり、売店あり',
+      websiteUrl: 'https://botanical.greenery-niigata.or.jp/',
+    ),
   ),
   Spot(
+    id: 'uwasekigata-001',
     title: '上堰潟公園 桜と菜の花',
     location: '新潟市西蒲区松野尾1（上堰潟公園）',
     image: 'assets/images/cherryblossom.png',
@@ -115,6 +196,18 @@ const List<Spot> spots = [
     touristDescription: '上堰潟公園は、湖面や芝生広場、遊歩道、バーベキュー施設、遊具などが整備された自然豊かな公園です。春は桜と菜の花、秋はコスモスが楽しめます。',
     latitude: 37.79090734939392,
     longitude: 138.86637776491642,
+    flowerInfo: FlowerInfo(
+      scientificName: 'Prunus × yedoensis & Brassica rapa',
+      bloomPeriod: '4-5月',
+      bestViewingTime: '4月中旬',
+      flowerLanguage: '精神美・快活',
+    ),
+    sightseeingInfo: SightseeingInfo(
+      nearbyAttractions: '角田山、弥彦神社、燕三条駅',
+      accessInfo: 'JR巻駅からバスで15分、上堰潟公園前下車',
+      facilities: '駐車場あり、トイレあり、バーベキュー施設、遊具',
+      websiteUrl: 'https://www.city.niigata.lg.jp/nishikan/shisetsu/kanko/koen/uwasekigata.html',
+    ),
   ),
   // Spot(
   //   title: '上堰潟公園 コスモス',

--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -1,4 +1,56 @@
+/// Flower-specific information for spots
+class FlowerInfo {
+  final String scientificName;
+  final String bloomPeriod;
+  final String bestViewingTime;
+  final String flowerLanguage;
+  final String? referenceUrl;
+
+  const FlowerInfo({
+    required this.scientificName,
+    required this.bloomPeriod,
+    required this.bestViewingTime,
+    required this.flowerLanguage,
+    this.referenceUrl,
+  });
+
+  factory FlowerInfo.fromMap(Map<String, dynamic> map) {
+    return FlowerInfo(
+      scientificName: map['scientific_name'] ?? '',
+      bloomPeriod: map['bloom_period'] ?? '',
+      bestViewingTime: map['best_viewing_time'] ?? '',
+      flowerLanguage: map['flower_language'] ?? '',
+      referenceUrl: map['reference_url'],
+    );
+  }
+}
+
+/// Sightseeing-specific information for spots
+class SightseeingInfo {
+  final String nearbyAttractions;
+  final String accessInfo;
+  final String facilities;
+  final String? websiteUrl;
+
+  const SightseeingInfo({
+    required this.nearbyAttractions,
+    required this.accessInfo,
+    required this.facilities,
+    this.websiteUrl,
+  });
+
+  factory SightseeingInfo.fromMap(Map<String, dynamic> map) {
+    return SightseeingInfo(
+      nearbyAttractions: map['nearby_attractions'] ?? '',
+      accessInfo: map['access_info'] ?? '',
+      facilities: map['facilities'] ?? '',
+      websiteUrl: map['website_url'],
+    );
+  }
+}
+
 class Spot {
+  final String id;
   final String title;
   final String location;
   final String image;
@@ -9,8 +61,11 @@ class Spot {
   final double latitude;
   final double longitude;
   final bool isDemo; // デモスポットかどうかを識別
+  final FlowerInfo? flowerInfo;
+  final SightseeingInfo? sightseeingInfo;
 
   const Spot({
+    required this.id,
     required this.title,
     required this.location,
     required this.image,
@@ -21,10 +76,13 @@ class Spot {
     required this.latitude,
     required this.longitude,
     this.isDemo = false, // デフォルトはfalse
+    this.flowerInfo,
+    this.sightseeingInfo,
   });
 
   factory Spot.fromMap(Map<String, dynamic> map) {
     return Spot(
+      id: map['id'] ?? '',
       title: map['title'] ?? '',
       location: map['location'] ?? '',
       image: map['image'] ?? '',
@@ -35,6 +93,12 @@ class Spot {
       latitude: map['latitude'] ?? 0.0,
       longitude: map['longitude'] ?? 0.0,
       isDemo: map['isDemo'] ?? false,
+      flowerInfo: map['flower_info'] != null 
+          ? FlowerInfo.fromMap(map['flower_info']) 
+          : null,
+      sightseeingInfo: map['sightseeing_info'] != null 
+          ? SightseeingInfo.fromMap(map['sightseeing_info']) 
+          : null,
     );
   }
 } 

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import '../data/spots.dart';
 import '../widgets/map_marker.dart';
 import '../widgets/tourist_info_card.dart';
-import '../widgets/spot_detail_card.dart';
+import '../widgets/spot_detail_sheet.dart';
 import '../widgets/nearby_spots_widget.dart';
 import '../widgets/stamp_collection_button.dart';
 import 'package:geolocator/geolocator.dart';
@@ -19,11 +19,10 @@ class MapScreen extends StatefulWidget {
 }
 
 class _MapScreenState extends State<MapScreen> {
-  int? _selectedIndex;
-  bool _showTouristInfo = false;
   LatLng? _currentPosition;
   GoogleMapController? _mapController;
   final Set<Marker> _markers = {};
+  bool _isBottomSheetOpen = false;
 
   @override
   void initState() {
@@ -44,10 +43,12 @@ class _MapScreenState extends State<MapScreen> {
             title: spot.title,
             snippet: spot.location,
             onTap: () {
-              setState(() {
-                _selectedIndex = i;
-                _showTouristInfo = false;
-              });
+              showSpotDetailSheet(
+                context, 
+                spot,
+                onShow: () => setState(() => _isBottomSheetOpen = true),
+                onHide: () => setState(() => _isBottomSheetOpen = false),
+              );
             },
           ),
         ),
@@ -140,6 +141,10 @@ class _MapScreenState extends State<MapScreen> {
                           },
                           myLocationEnabled: _currentPosition != null,
                           myLocationButtonEnabled: true,
+                          zoomGesturesEnabled: !_isBottomSheetOpen,
+                          scrollGesturesEnabled: !_isBottomSheetOpen,
+                          tiltGesturesEnabled: !_isBottomSheetOpen,
+                          rotateGesturesEnabled: !_isBottomSheetOpen,
                           markers: {
                             ..._markers,
                             if (_currentPosition != null)
@@ -159,31 +164,7 @@ class _MapScreenState extends State<MapScreen> {
                         right: 32,
                         child: _buildSearchBar(),
                       ),
-                    for (var i = 0; i < spots.length; i++)
-                        Positioned(
-                          top: 100.0 + i * 80,
-                          left: 60.0 + (i % 2) * 120,
-                          child: GestureDetector(
-                            onTap: () => setState(() => _selectedIndex = i),
-                          child: const MapMarker(),
-                        ),
-                      ),
-                      if (_selectedIndex != null)
-                        Positioned(
-                          bottom: 100,
-                          left: 16,
-                          right: 16,
-                          child: _showTouristInfo
-                            ? TouristInfoCard(
-                                data: spots[_selectedIndex!],
-                                  onClose: () => setState(() => _showTouristInfo = false),
-                                )
-                            : SpotDetailCard(
-                                data: spots[_selectedIndex!],
-                                  onClose: () => setState(() => _selectedIndex = null),
-                                  onTouristInfo: () => setState(() => _showTouristInfo = true),
-                                ),
-                        ),
+
                     ],
                   ),
                 ),

--- a/lib/widgets/spot_detail_sheet.dart
+++ b/lib/widgets/spot_detail_sheet.dart
@@ -1,0 +1,560 @@
+import 'package:flutter/material.dart';
+import 'package:expandable_text/expandable_text.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/spot.dart';
+import 'stamp_collection_button.dart';
+import 'spot_action_button.dart';
+
+class SpotDetailSheet extends StatefulWidget {
+  final Spot spot;
+
+  const SpotDetailSheet({
+    required this.spot,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<SpotDetailSheet> createState() => _SpotDetailSheetState();
+}
+
+class _SpotDetailSheetState extends State<SpotDetailSheet> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+    
+    return Center(
+      child: Container(
+        width: screenWidth * 0.9,
+        height: screenHeight * 0.8,
+        margin: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(24),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 20,
+              offset: const Offset(0, 10),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Header with close button
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Flexible(
+                    child: Text(
+                      widget.spot.title,
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                      softWrap: true,
+                      overflow: TextOverflow.visible,
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close),
+                    style: IconButton.styleFrom(
+                      backgroundColor: colorScheme.surfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Segmented Button for content switching
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: SegmentedButton<int>(
+                segments: const [
+                  ButtonSegment(
+                    value: 0,
+                    label: Text('スポット'),
+                    icon: Icon(Icons.location_on),
+                  ),
+                  ButtonSegment(
+                    value: 1,
+                    label: Text('花情報'),
+                    icon: Icon(Icons.local_florist),
+                  ),
+                  ButtonSegment(
+                    value: 2,
+                    label: Text('観光情報'),
+                    icon: Icon(Icons.camera_alt),
+                  ),
+                ],
+                selected: <int>{_selectedIndex},
+                showSelectedIcon: false,
+                onSelectionChanged: (Set<int> newSelection) {
+                  setState(() {
+                    _selectedIndex = newSelection.first;
+                  });
+                },
+              ),
+            ),
+
+            // Content area with IndexedStack
+            Expanded(
+              child: IndexedStack(
+                index: _selectedIndex,
+                children: [
+                  _SpotInfoView(
+                    spot: widget.spot,
+                    scrollController: ScrollController(),
+                  ),
+                  _FlowerInfoView(
+                    spot: widget.spot,
+                    scrollController: ScrollController(),
+                  ),
+                  _SightseeingInfoView(
+                    spot: widget.spot,
+                    scrollController: ScrollController(),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Basic spot information view
+class _SpotInfoView extends StatelessWidget {
+  final Spot spot;
+  final ScrollController scrollController;
+
+  const _SpotInfoView({
+    required this.spot,
+    required this.scrollController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    
+    return SingleChildScrollView(
+      controller: scrollController,
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Spot image
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: AspectRatio(
+              aspectRatio: 16 / 9,
+              child: Image.asset(
+                spot.image,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Container(
+                    color: colorScheme.surfaceVariant,
+                    child: Icon(
+                      Icons.image_not_supported,
+                      size: 48,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // Location with icon
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.location_on,
+                size: 20,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(width: 8),
+              Flexible(
+                child: Text(
+                  spot.location,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                  softWrap: true,
+                  overflow: TextOverflow.visible,
+                ),
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // Distance indicator (placeholder)
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.near_me,
+                      size: 16,
+                      color: colorScheme.onPrimaryContainer,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '0m',
+                      style: TextStyle(
+                        color: colorScheme.onPrimaryContainer,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // Description with expandable text
+          ExpandableText(
+            spot.description,
+            expandText: ' 続きを読む',
+            collapseText: ' 閉じる',
+            maxLines: 3,
+            linkColor: colorScheme.primary,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              height: 1.5,
+            ),
+          ),
+          
+          const SizedBox(height: 24),
+          
+          // Stamp collection button
+          StampCollectionButton(spot: spot),
+          
+          const SizedBox(height: 16),
+          
+          // Action buttons
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              SpotActionButton(
+                icon: Icons.map,
+                label: 'マップ',
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              SpotActionButton(
+                icon: Icons.near_me,
+                label: 'ルート',
+                onPressed: () {},
+              ),
+              SpotActionButton(
+                icon: Icons.camera_alt,
+                label: 'AR',
+                onPressed: () {},
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+/// Flower information view
+class _FlowerInfoView extends StatelessWidget {
+  final Spot spot;
+  final ScrollController scrollController;
+
+  const _FlowerInfoView({
+    required this.spot,
+    required this.scrollController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final flowerInfo = spot.flowerInfo;
+
+    return SingleChildScrollView(
+      controller: scrollController,
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (flowerInfo != null) ...[
+            _InfoRow(
+              icon: Icons.science,
+              label: '学名',
+              value: flowerInfo.scientificName,
+              isItalic: true,
+            ),
+            const SizedBox(height: 16),
+            _InfoRow(
+              icon: Icons.calendar_today,
+              label: '花期',
+              value: flowerInfo.bloomPeriod,
+            ),
+            const SizedBox(height: 16),
+            _InfoRow(
+              icon: Icons.visibility,
+              label: '見頃',
+              value: flowerInfo.bestViewingTime,
+            ),
+            const SizedBox(height: 16),
+            _InfoRow(
+              icon: Icons.favorite,
+              label: '花言葉',
+              value: flowerInfo.flowerLanguage,
+            ),
+            const SizedBox(height: 16),
+            if (flowerInfo.referenceUrl != null) ...[
+              Row(
+                children: [
+                  Icon(
+                    Icons.link,
+                    size: 20,
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      '参考サイト',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton.icon(
+                onPressed: () => _launchUrl(flowerInfo.referenceUrl!),
+                icon: const Icon(Icons.open_in_new),
+                label: const Text('外部リンクを開く'),
+              ),
+            ],
+          ] else ...[
+            // No flower info available
+            Center(
+              child: Column(
+                children: [
+                  Icon(
+                    Icons.local_florist_outlined,
+                    size: 64,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '花情報はまだ準備中です',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+/// Sightseeing information view
+class _SightseeingInfoView extends StatelessWidget {
+  final Spot spot;
+  final ScrollController scrollController;
+
+  const _SightseeingInfoView({
+    required this.spot,
+    required this.scrollController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final sightseeingInfo = spot.sightseeingInfo;
+
+    return SingleChildScrollView(
+      controller: scrollController,
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (sightseeingInfo != null) ...[
+            _InfoRow(
+              icon: Icons.place,
+              label: '周辺観光地',
+              value: sightseeingInfo.nearbyAttractions,
+            ),
+            const SizedBox(height: 16),
+            _InfoRow(
+              icon: Icons.directions,
+              label: 'アクセス',
+              value: sightseeingInfo.accessInfo,
+            ),
+            const SizedBox(height: 16),
+            _InfoRow(
+              icon: Icons.local_parking,
+              label: '施設',
+              value: sightseeingInfo.facilities,
+            ),
+            const SizedBox(height: 16),
+            if (sightseeingInfo.websiteUrl != null) ...[
+              Row(
+                children: [
+                  Icon(
+                    Icons.web,
+                    size: 20,
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      '公式サイト',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton.icon(
+                onPressed: () => _launchUrl(sightseeingInfo.websiteUrl!),
+                icon: const Icon(Icons.open_in_new),
+                label: const Text('公式サイトを開く'),
+              ),
+            ],
+          ] else ...[
+            // No sightseeing info available
+            Center(
+              child: Column(
+                children: [
+                  Icon(
+                    Icons.camera_alt_outlined,
+                    size: 64,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '観光情報はまだ準備中です',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+/// Reusable info row widget
+class _InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final bool isItalic;
+
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.isItalic = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          icon,
+          size: 20,
+          color: colorScheme.primary,
+        ),
+        const SizedBox(width: 8),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w500,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                value,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontStyle: isItalic ? FontStyle.italic : null,
+                ),
+                softWrap: true,
+                overflow: TextOverflow.visible,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Helper function to launch URLs
+Future<void> _launchUrl(String url) async {
+  final Uri uri = Uri.parse(url);
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } else {
+    throw 'Could not launch $url';
+  }
+}
+
+/// Helper function to show the spot detail sheet
+void showSpotDetailSheet(BuildContext context, Spot spot, {VoidCallback? onShow, VoidCallback? onHide}) {
+  // マップ操作を無効化
+  if (onShow != null) onShow();
+  
+  showDialog(
+    context: context,
+    barrierColor: Colors.black.withOpacity(0.5),
+    barrierDismissible: true,
+    builder: (context) => SpotDetailSheet(spot: spot),
+  ).then((_) {
+    // シートが閉じられた時にマップ操作を再有効化
+    if (onHide != null) onHide();
+  });
+} 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import firebase_auth
 import firebase_core
 import geolocator_apple
 import package_info_plus
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -19,4 +20,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  expandable_text:
+    dependency: "direct main"
+    description:
+      name: expandable_text
+      sha256: "7d03ea48af6987b20ece232678b744862aa3250d4a71e2aaf1e4af90015d76b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -597,6 +605,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   geolocator: ^14.0.2
   geolocator_platform_interface: ^4.2.4
   provider: ^6.0.5
+  expandable_text: ^2.3.0
+  url_launcher: ^6.2.2
   # flutter_unity_widget: ^2022.2.0
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <geolocator_windows/geolocator_windows.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -20,4 +21,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   geolocator_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## 概要
<!-- この PR の目的や背景を簡潔に記載してください -->
- スポット詳細表示画面の完全リニューアルによるユーザー体験の大幅向上
- 花情報・観光情報を分離した3タブ式UIによる情報の整理と視認性向上
- データモデルの拡張により実用的な花図鑑アプリとしての機能完成
- Firestore移行戦略の策定と料金試算による運用計画の明確化

## 🛠️ 変更内容
<!-- 何をどう変更したかを箇条書きで -->

### UI/UX大幅刷新
- **表示方式変更**: DraggableScrollableSheet → 中央表示ダイアログ
- **タブ式UI**: SegmentedButtonによる3タブ切り替え（スポット/花情報/観光情報）
- **レスポンシブ対応**: 画面サイズに応じた適切なレイアウト
- **マップ操作制限**: ダイアログ表示中のマップジェスチャー無効化

### データモデル拡張
- **FlowerInfo追加**: 学名（イタリック表記）、花期、見頃、花言葉、参考サイト
- **SightseeingInfo追加**: 周辺観光地、アクセス情報、施設、公式サイト
- **Spotモデル拡張**: 全スポットにID・花情報・観光情報を追加
- **実データ充実**: 8スポット全てに詳細な花・観光情報を設定

### 新機能実装
- **ExpandableText**: 「続きを読む」機能による長文の適切な表示
- **外部リンク**: url_launcherによる参考サイト・公式サイトへの遷移
- **個別スクロール**: 各タブで独立したスクロール状態の保持
- **エラーハンドリング**: 画像読み込み失敗時の代替表示

### パッケージ追加
- `expandable_text: ^2.3.0` - 続きを読む機能
- `url_launcher: ^6.2.2` - 外部リンク機能

## 🔧 技術的詳細

### アーキテクチャ改善
- **IndexedStack活用**: タブ切り替え時の状態保持
- **Theme統一**: colorSchemeによる一貫したデザイン
- **Null Safety**: 完全なnull安全性の保証
- **メモリ効率**: 適切なWidgetライフサイクル管理

### データ構造最適化
```dart
class FlowerInfo {
  final String scientificName;    // 学名
  final String bloomPeriod;       // 花期
  final String bestViewingTime;   // 見頃
  final String flowerLanguage;    // 花言葉
  final String? referenceUrl;     // 参考サイト
}

class SightseeingInfo {
  final String nearbyAttractions; // 周辺観光地
  final String accessInfo;        // アクセス
  final String facilities;        // 施設
  final String? websiteUrl;       // 公式サイト
}
```

### UI/UX設計原則
- **中央表示**: 画面幅90%・高さ80%の適切なサイズ
- **アクセシビリティ**: 十分なコントラスト比とタッチターゲット
- **直感的操作**: セグメントボタンによる明確なタブ切り替え
- **情報階層**: 基本情報→専門情報→周辺情報の論理的配置

## 🎮 使用方法・動作確認

### 通常実行
```bash
flutter pub get
flutter run -d chrome
```

### 新機能テスト項目
1. **詳細ダイアログ表示**:
   - ✅ マップ上のマーカーをタップ → 中央にダイアログ表示
   - ✅ 画面サイズに応じたレスポンシブ対応

2. **3タブ切り替え機能**:
   - ✅ 「スポット」タブ: 基本情報・画像・続きを読む機能
   - ✅ 「花情報」タブ: 学名（イタリック）・花期・見頃・花言葉
   - ✅ 「観光情報」タブ: 周辺観光地・アクセス・施設

3. **インタラクション機能**:
   - ✅ 外部リンクボタン: 参考サイト・公式サイトへの遷移
   - ✅ 続きを読む機能: 長文の適切な表示制御
   - ✅ マップ操作制限: ダイアログ表示中のジェスチャー無効化

4. **データ表示確認**:
   - ✅ 全8スポットで花情報・観光情報が正しく表示
   - ✅ 学名のイタリック表記
   - ✅ 未設定情報の適切な代替表示

## 📊 改善された点

### ユーザー体験
- **情報整理**: 3タブによる情報の論理的分類
- **視認性向上**: 中央表示による見やすいレイアウト
- **操作性改善**: マップとダイアログの干渉解消
- **情報量増加**: 実用的な花・観光情報の充実

### 開発・運用面
- **拡張性**: モジュール化されたデータ構造
- **保守性**: 型安全な実装とエラーハンドリング
- **パフォーマンス**: 効率的なWidget構成
- **料金試算**: Firestore移行時の明確な運用計画

## 🔍 解決された問題

### UI/UX課題
**問題**: 従来のボトムシートによる表示制限  
**解決**: 中央ダイアログによる十分な表示領域確保

**問題**: 情報の混在による可読性低下  
**解決**: 3タブによる情報の適切な分類・整理

**問題**: マップ操作との干渉  
**解決**: ダイアログ表示中のマップジェスチャー制限

### データ構造課題
**問題**: 花・観光情報の不足  
**解決**: 専用モデルによる構造化された詳細情報

**問題**: 外部情報への誘導不足  
**解決**: url_launcherによる適切な外部リンク機能

## 🔒 Firestore移行戦略

### 料金試算（月間1,000ユーザー想定）
- **読み込み**: 15,000 reads × $0.06/100,000 = $0.009/月
- **書き込み**: 2,500 writes × $0.18/100,000 = $0.0045/月
- **合計**: 約$0.014/月（約2円/月）

### 無料枠との比較
- **読み込み無料枠**: 50,000 reads/月 → 余裕あり
- **書き込み無料枠**: 20,000 writes/月 → 余裕あり
- **結論**: 無料枠内で運用可能

### 課金抑制戦略
1. **ページング**: `limit(10)`による取得件数制限
2. **キャッシュ**: オフライン持続性による重複取得防止
3. **範囲クエリ**: 位置情報による必要データの絞り込み

## ✅ 実装された機能
- ✅ 3タブ式スポット詳細表示システム
- ✅ 花情報・観光情報の構造化データモデル
- ✅ ExpandableTextによる続きを読む機能
- ✅ url_launcherによる外部リンク機能
- ✅ レスポンシブな中央ダイアログ表示
- ✅ マップ操作制限による干渉防止
- ✅ 包括的なエラーハンドリング
- ✅ Firestore移行戦略の策定

## 🔄 変更ファイル一覧
- `lib/models/spot.dart` - FlowerInfo・SightseeingInfo追加
- `lib/widgets/spot_detail_sheet.dart` - 完全リニューアル
- `lib/data/spots.dart` - 全スポットデータの拡張
- `lib/screens/map_screen.dart` - マップ操作制限機能
- `pubspec.yaml` - 新パッケージ追加
- `README.md` - Firestore移行戦略追加

## 💡 今後の拡張予定
- **AR機能**: 花の3Dモデル表示
- **検索機能**: 花期・地域による絞り込み
- **お気に入り機能**: スポットのブックマーク
- **ルート機能**: Google Maps連携ナビゲーション
- **統計機能**: スタンプ取得状況の可視化

## 📝 関連 Issue / PR
- 前回: Firebase認証・スタンプ機能実装（#20）
- 今回: スポット詳細画面刷新・データモデル拡張（#23）
- 次回予定: AR機能実装・検索機能追加

## 🚨 注意事項
- **新パッケージ**: `flutter pub get`による依存関係更新必須
- **データ移行**: 既存スポットデータにID・詳細情報を追加
- **外部リンク**: url_launcherのプラットフォーム設定確認推奨