### PR TITLE
feat: スポット専用スタンプ画像の実装

### DIFF
--- a/lib/data/spots.dart
+++ b/lib/data/spots.dart
@@ -12,6 +12,7 @@ const List<Spot> spots = [
       'assets/images/tulip.png',
       'assets/images/backgroundflower.png',
     ],
+    stampImage: 'assets/images/cosmos.png', // スタンプ画像を追加
     description: 'これはデモ用のスポットです。位置情報に関係なく、どこからでもスタンプを取得できます。実際のアプリでは、スポットの近くに行く必要があります。',
     touristTitle: 'デモ観光情報',
     touristLocation: 'デモ用観光スポット',
@@ -48,6 +49,7 @@ const List<Spot> spots = [
       'assets/images/cherryblossom2.png',
       'assets/images/cherry_rapeblossoms.png',
     ],
+    stampImage: 'assets/images/cherryblossom2.png', // スタンプ画像を追加
     description: 'デモ用の桜スポットです。スタンプ取得のテストに使用できます。実際の運用では位置情報による制限があります。',
     touristTitle: 'デモ桜観光地',
     touristLocation: 'デモ用桜の名所',
@@ -85,6 +87,7 @@ const List<Spot> spots = [
       'assets/photos/tulip_gosen2.JPG',
       'assets/photos/tulip_gosen3.JPG',
     ],
+    stampImage: 'assets/images/tulip.png', // スタンプ画像を追加
     description: '五泉市は、新潟県内でも有数のチューリップの産地として知られています。五泉市では、チューリップの球根を出荷するだけでなく、市民や観光客にも楽しんでもらえるよう、生産者に依頼して巣本地区にチューリップの畑を集め、チューリップまつりを毎年開催しています。最近では、オランダなどから新たな品種の球根を輸入して栽培するなど、多種多様な花が咲き誇っています。',
     touristTitle: 'ラポルテ五泉',
     touristLocation: '五泉市赤海863番地',
@@ -120,6 +123,7 @@ const List<Spot> spots = [
       'assets/photos/hakusan2_niigatatourism.jpg',
       'assets/photos/hakusan3_niigatatourism.jpg',
     ],
+    stampImage: 'assets/images/cherryblossom.png', // スタンプ画像を追加
     description: '新潟市の白山公園では、毎年春に桜まつりが開催されます。約400本の桜が咲き誇り、夜にはライトアップも行われます。花見客で賑わう人気のスポットです。',
     touristTitle: '新潟市歴史博物館',
     touristLocation: '新潟市中央区柳島町2-10',
@@ -176,6 +180,7 @@ const List<Spot> spots = [
       'assets/photos/fukusimagata3_niigatatourism.jpg',
       'assets/photos/fukusimagata4_niigatatourism.jpg',
     ],
+    stampImage: 'assets/images/rapeblossoms.png', // スタンプ画像を追加
     description: '福島潟は新潟市の東方に位置し、春には菜の花が一面に咲き誇る自然豊かな潟です。220種以上の野鳥や450種以上の植物が生息し、四季折々の風景が楽しめます。菜の花の黄色いじゅうたんと潟の水面、遠くの五頭連峰の眺めは圧巻です。',
     touristTitle: '水の駅「ビュー福島潟」',
     touristLocation: '新潟市北区前新田乙493',
@@ -221,6 +226,7 @@ const List<Spot> spots = [
       'assets/photos/shokubutsuen_lotus1.JPG',
       'assets/photos/shokubutsuen_lotus2.JPG',
     ],
+    stampImage: 'assets/images/lotus.png', // スタンプ画像を追加
     description: '新潟県立植物園では、夏になると水生植物園の池で美しいハスの花が咲き誇ります。広大な園内には国内外の多様な植物が展示されており、ハスの花とともに四季折々の自然を楽しめます。',
     touristTitle: '新潟県立植物園',
     touristLocation: '新潟市秋葉区金津186',
@@ -255,6 +261,7 @@ const List<Spot> spots = [
       'assets/photos/uwasekigata2_niigatatourism.jpg',
       'assets/photos/uwasekigata4_niigatatourism.jpg',
     ],
+    stampImage: 'assets/images/cherry_rapeblossoms.png', // スタンプ画像を追加
     description: '上堰潟公園は角田山の麓に広がる開放感あふれる公園で、春には桜と菜の花が同時に咲き誇り、ピンクと黄色のコントラストが美しい絶景スポットです。ピクニックや散策にも最適です。',
     touristTitle: '上堰潟公園',
     touristLocation: '新潟市西蒲区松野尾1',
@@ -289,6 +296,7 @@ const List<Spot> spots = [
       'assets/photos/ajisai2.JPG',
       'assets/photos/ajisai3.JPG',
     ],
+    stampImage: 'assets/images/hydrangea.png', // スタンプ画像を追加
     description: '護摩堂山あじさい園は、標高274mの護摩堂山山頂付近に広がる紫陽花の名所で、初夏になると約3万株ものあじさいが35,000㎡以上にわたって咲き誇ります。ガクアジサイを中心に、セイヨウアジサイなど複数の種類が混植され、青・紫・赤・白などバラエティに富んだ色彩が楽しめます。遊歩道沿いには花のトンネルのような風景が広がり、山頂からは越後平野、弥彦山、角田山、佐渡島なども望める絶好のビュースポットです。',
     touristTitle: '護摩堂山あじさい園・あじさい茶屋',
     touristLocation: '新潟県田上町田上',

--- a/lib/models/spot.dart
+++ b/lib/models/spot.dart
@@ -60,6 +60,7 @@ class Spot {
   final String location;
   final String image;
   final List<String> images; // 追加：複数の画像を保持
+  final String stampImage; // 追加：スタンプ専用の画像
   final String description;
   final String touristTitle;
   final String touristLocation;
@@ -76,6 +77,7 @@ class Spot {
     required this.location,
     required this.image,
     this.images = const [], // デフォルトは空リスト
+    String? stampImage, // オプショナルに変更
     required this.description,
     required this.touristTitle,
     required this.touristLocation,
@@ -85,7 +87,7 @@ class Spot {
     this.isDemo = false, // デフォルトはfalse
     this.flowerInfo,
     this.sightseeingInfo,
-  });
+  }) : stampImage = stampImage ?? image; // デフォルトとしてimageを使用
 
   // メインで表示する画像を取得するヘルパーメソッド
   List<String> get displayImages {
@@ -104,6 +106,7 @@ class Spot {
       images: map['images'] != null 
           ? List<String>.from(map['images']) 
           : const [],
+      stampImage: map['stamp_image'], // nullの場合はコンストラクタでimageを使用
       description: map['description'] ?? '',
       touristTitle: map['tourist_title'] ?? '',
       touristLocation: map['tourist_location'] ?? '',

--- a/lib/screens/stamps_collection_screen.dart
+++ b/lib/screens/stamps_collection_screen.dart
@@ -145,7 +145,7 @@ class StampCollectionScreen extends StatelessWidget {
                                 child: ClipOval(
                                   child: isCollected
                                     ? Image.asset(
-                                        spot.image,
+                                        spot.stampImage,
                                         fit: BoxFit.cover,
                                         errorBuilder: (context, error, stackTrace) {
                                           return Container(
@@ -300,7 +300,7 @@ class StampCollectionScreen extends StatelessWidget {
                   ),
                   child: ClipOval(
                     child: Image.asset(
-                      spot.image,
+                      spot.stampImage,
                       fit: BoxFit.cover,
                       errorBuilder: (context, error, stackTrace) {
                         return Container(

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -42,7 +42,7 @@ class FirestoreService {
         id: stampDoc.id,
         spotTitle: spot.title,
         spotLocation: spot.location,
-        spotImage: spot.image,
+        spotImage: spot.stampImage, // 修正：stampImageを使用
         userId: userId,
         collectedAt: DateTime.now(),
         latitude: userLatitude,


### PR DESCRIPTION
## 概要
<!-- この PR の目的や背景を簡潔に記載してください -->
- スポット写真とは独立した専用スタンプ画像の実装
- 後方互換性を保持した拡張性の高い実装

## 🛠️ 変更内容
<!-- 何をどう変更したかを箇条書きで -->

### モデル拡張
- **Spotモデル**: `stampImage`フィールドを追加
- **後方互換性**: `stampImage`がnullの場合は既存の`image`を使用する仕組み
- **fromMap対応**: データ読み込み時の`stamp_image`フィールド対応

### サービス層修正
- **FirestoreService**: スタンプ保存時に`spot.stampImage`を使用
- **スタンプデータ**: 各スポット専用の画像でスタンプを保存

### UI層修正
- **スタンプコレクション画面**: グリッドビューで専用スタンプ画像を表示
- **スタンプ詳細ダイアログ**: 詳細表示時に専用スタンプ画像を使用

### データ設定
- **全8スポット**: 各スポットに指定されたスタンプ画像を設定
- **スタンプ画像パス**: `assets/images/`配下の専用ファイルを指定

## 🔧 技術的詳細
- **フィールド追加**: `final String stampImage`をSpotクラスに追加
- **コンストラクタ**: `String? stampImage`をオプショナルで受け取り
- **デフォルト値**: `stampImage = stampImage ?? image`で後方互換性確保
- **データ取得**: `map['stamp_image']`でnullセーフに取得

## 🔍 解決された問題

### 主要課題: スタンプとスポット写真の区別不明
**問題**: スタンプ画像とスポット写真が同じで、コレクション性が低い  
**解決**: 各スポット専用のスタンプ画像を導入

### 技術詳細
- **従来の実装**:
  ```dart
  spotImage: spot.image // スポット写真をそのまま使用
  ```
- **新実装**:
  ```dart
  spotImage: spot.stampImage // 専用スタンプ画像を使用
  ```

## 🎮 設定されたスタンプ画像

### 実際のスポット
1. **五泉市チューリップまつり**
   - 🌷 `assets/images/tulip.png`
   - チューリップの特色を表現

2. **新潟市桜まつり**
   - 🌸 `assets/images/cherryblossom.png`
   - 桜の美しさを表現

3. **福島潟 菜の花畑**
   - 🌻 `assets/images/rapeblossoms.png`
   - 菜の花の黄色い絨毯を表現

4. **新潟県立植物園 ハスの花**
   - 🪷 `assets/images/lotus.png`
   - 蓮の花の気品を表現

5. **上堰潟公園 桜と菜の花**
   - 🌸🌻 `assets/images/cherry_rapeblossoms.png`
   - 桜と菜の花のコントラストを表現

6. **護摩堂山アジサイ園**
   - 🌺 `assets/images/hydrangea.png`
   - アジサイの色彩豊かさを表現

### デモスポット
7. **【デモ】テスト桜スポット**
   - 🌸 `assets/images/cherryblossom2.png`
   - デモ用の桜バリエーション

8. **【デモ】サンプル花畑**
   - 🌼 `assets/images/cosmos.png`
   - コスモスの可憐さを表現

## 📊 実装の特徴
- **後方互換性**: 既存のコードへの影響を最小限に抑制
- **拡張性**: 新しいスポット追加時も簡単に対応可能
- **視覚的魅力**: 各スポットの特色を活かしたスタンプデザイン
- **一貫性**: 全スポットで統一されたスタンプ表示方式

## 🔒 データ整合性・品質
- **フィールド追加**: 既存データへの影響なし
- **デフォルト値**: null時の適切なフォールバック
- **型安全**: Dartの型システムによる安全な実装
- **テスト対応**: デモスポットでの動作確認可能

## ✅ 動作確認手順
1. **リポジトリ更新**
   ```bash
   git fetch origin feature/feature#36
   git checkout feature/feature#36
   flutter pub get
   ```

2. **アプリ実行**
   ```bash
   flutter run -d chrome --dart-define=DEMO=true
   ```

3. **機能テスト項目**
   - **スタンプ取得**: 各スポットでスタンプが正常に取得できる
   - **専用画像表示**: 取得済みスタンプで専用画像が表示される
   - **コレクション画面**: スタンプコレクション画面で専用画像が表示される
   - **詳細ダイアログ**: スタンプ詳細で専用画像が表示される
   - **デモ動作**: デモスポットでも専用画像が正常動作する

## 🎯 実装された機能
- ✅ SpotモデルへのstampImageフィールド追加
- ✅ FirestoreServiceでの専用スタンプ画像保存
- ✅ スタンプコレクション画面での専用画像表示
- ✅ 全8スポットの専用スタンプ画像設定
- ✅ 後方互換性の保持
- ✅ デモスポット対応

## 🐛 修正されたバグ・改善点
- **視覚的区別**: スタンプとスポット写真の明確な区別
- **コレクション性**: 各スポットの特色を活かしたスタンプデザイン
- **ユーザー体験**: より魅力的なスタンプコレクション体験
- **データ構造**: 拡張性の高いデータモデル

## 💡 今後の拡張予定
- **季節限定スタンプ**: 時期に応じた特別なスタンプ画像
- **アニメーション**: スタンプ取得時のアニメーション効果
- **カスタマイズ**: ユーザーによるスタンプ選択機能
- **統計表示**: スタンプ種類別の取得状況分析

## 📝 関連 Issue / PR
- Issue #36: スタンプ画像の独立化要求
- 今回: 専用スタンプ画像の導入
- 次回予定: スタンプアニメーション・エフェクト実装

## 🚨 注意事項
- **画像アセット**: 指定されたスタンプ画像ファイルが必要
- **後方互換性**: 既存のスタンプデータは影響なし
- **開発環境**: 新規開発者は画像アセットの配置が必要

## 🔄 変更されたファイル
- `lib/models/spot.dart` - stampImageフィールド追加
- `lib/services/firestore_service.dart` - スタンプ保存時の画像指定
- `lib/screens/stamps_collection_screen.dart` - スタンプ表示の修正
- `lib/data/spots.dart` - 全8スポットのスタンプ画像設定