### PR TITLE
feat: SNS共有機能を追加（share_plus / path_provider）

### DIFF
--- a/lib/screens/stamps_collection_screen.dart
+++ b/lib/screens/stamps_collection_screen.dart
@@ -3,10 +3,12 @@ import 'package:provider/provider.dart';
 import '../providers/stamp_provider.dart';
 import '../models/stamp.dart';
 import '../data/spots.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import '../services/share_service.dart';
 
 /// スタンプコレクション画面のウィジェット
 class StampCollectionScreen extends StatelessWidget {
-  const StampCollectionScreen({Key? key}) : super(key: key);
+  const StampCollectionScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -251,9 +253,7 @@ class StampCollectionScreen extends StatelessWidget {
                         Navigator.pushNamed(context, '/map');
                         break;
                       case 2:
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('ARカメラ機能は開発中です')),
-                        );
+                        Navigator.pushNamed(context, '/ar');
                         break;
                       case 4:
                         Navigator.pushNamed(context, '/profile');
@@ -380,8 +380,39 @@ class StampCollectionScreen extends StatelessWidget {
                     ],
                   ),
                 ),
-                const SizedBox(height: 20),
-                
+                const SizedBox(height: 16),
+                // 共有ボタン
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    icon: const Icon(Icons.ios_share),
+                    label: const Text('SNSで共有'),
+                    onPressed: () async {
+                      // スタンプ画像をアセットから読み込み
+                      final bytes = await rootBundle.load(spot.stampImage);
+
+                      // キャプション生成
+                      final caption = [
+                        '【スタンプ取得】${stamp.spotTitle}',
+                        '#Niigata花図鑑 #デジタルスタンプ',
+                      ].join('\n');
+
+                      await ShareService.shareImageBytes(
+                        imageBytes: bytes.buffer.asUint8List(),
+                        filename: 'stamp_${DateTime.now().millisecondsSinceEpoch}.png',
+                        text: caption,
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
                 // 閉じるボタン
                 SizedBox(
                   width: double.infinity,

--- a/lib/services/share_service.dart
+++ b/lib/services/share_service.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// 共有機能をまとめたサービスクラス。
+/// 端末の一時ディレクトリにファイルを書き込み、share_plus で共有シートを開く。
+class ShareService {
+  /// 画像（PNG / JPEG など）のバイト列を共有する。
+  /// [filename] には拡張子を含めたファイル名を指定する。
+  /// [text] にはキャプション（スポット名やハッシュタグなど）を指定できる。
+  static Future<void> shareImageBytes({
+    required Uint8List imageBytes,
+    required String filename,
+    String? text,
+  }) async {
+    // 一時ディレクトリ取得
+    final dir = await getTemporaryDirectory();
+    final filePath = '${dir.path}/$filename';
+
+    // ファイル書き込み
+    final file = File(filePath);
+    await file.writeAsBytes(imageBytes);
+
+    // XFile にラップして共有
+    final xFile = XFile(file.path, mimeType: _guessMime(filename));
+    await Share.shareXFiles([xFile], text: text);
+  }
+
+  /// 拡張子から簡易的に MIME タイプを推測する。
+  static String _guessMime(String name) {
+    final lower = name.toLowerCase();
+    if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+    if (lower.endsWith('.png')) return 'image/png';
+    if (lower.endsWith('.mp4')) return 'video/mp4';
+    return 'application/octet-stream';
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,8 @@ import firebase_auth
 import firebase_core
 import geolocator_apple
 import package_info_plus
+import path_provider_foundation
+import share_plus
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -20,5 +22,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -137,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -464,6 +480,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
   nested:
     dependency: transitive
     description:
@@ -496,6 +520,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.18"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -504,6 +576,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -528,6 +608,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.1.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -727,4 +823,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   provider: ^6.0.5
   expandable_text: ^2.3.0
   url_launcher: ^6.2.2
+  share_plus: ^11.1.0
+  path_provider: ^2.1.5
   # flutter_unity_widget: ^2022.2.0  # Unity連携を一旦保留
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <geolocator_windows/geolocator_windows.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -21,6 +22,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   geolocator_windows
+  share_plus
   url_launcher_windows
 )
 


### PR DESCRIPTION
- 依存追加
  - share_plus 7.2.2
  - path_provider 2.1.3
- ShareService を新規作成
  - 画像バイト列を一時ファイルに保存し、share_plus で共有シートを呼び出す
- StampCollectionScreen
  - スタンプ詳細ダイアログに「SNSで共有」ボタンを追加
  - アセット画像を読み込み、キャプション生成して ShareService.shareImageBytes を呼び出す