### PR TITLE
feat: DEMOフラグ導入・ARプレビュー追加・UI調整・Unity連携下地（iOS）ほか

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ Desktop.ini
 # ===================================================================
 assets/images/laporteshoukai.jpg
 assets/photos/
+assets/videos/tulip.mp4
 
 # ===================================================================
 # API keyなど

--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ Desktop.ini
 assets/images/laporteshoukai.jpg
 assets/photos/
 assets/videos/tulip.mp4
+assets/videos/README.md
 
 # ===================================================================
 # API keyなど

--- a/.gitignore
+++ b/.gitignore
@@ -124,16 +124,6 @@ UserSettings/
 *.booproj
 *.vsconfig
 
-# Unity as a Library（iOS/Android の生成物）
-ios/UnityLibrary/
-android/unityLibrary/
-android/app/src/main/assets/unityLibrary/
-
-# Android unityLibrary のビルド中間物（保険）
-android/unityLibrary/.gradle/
-android/unityLibrary/build/
-android/unityLibrary/obj/
-
 # Rider
 .idea/
 

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,5 @@ ios/Config/Keys.xcconfig
 /android/unityLibrary/.gradle/
 /android/unityLibrary/build/
 /android/unityLibrary/obj/
+
+ios/UnityLibrary/

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,16 @@ UserSettings/
 *.booproj
 *.vsconfig
 
+# Unity as a Library（iOS/Android の生成物）
+ios/UnityLibrary/
+android/unityLibrary/
+android/app/src/main/assets/unityLibrary/
+
+# Android unityLibrary のビルド中間物（保険）
+android/unityLibrary/.gradle/
+android/unityLibrary/build/
+android/unityLibrary/obj/
+
 # Rider
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,49 @@ firebase init
 flutter run
 ```
 
+### デモモード切り替え（ビルドフラグ）
+
+開発・検証時はデモ用スポットを有効化できます。`--dart-define=DEMO=true` を付与してください。本番ビルドでは必ず `DEMO=false` にします。
+
+```bash
+# ローカル実行（Chrome）
+flutter run -d chrome --dart-define=DEMO=true
+
+# Web ビルド（develop 用）
+flutter build web --release \
+  --dart-define=DEMO=true \
+  --base-href "/<repo_name>/"
+
+# 本番（main 用）
+flutter build web --release \
+  --dart-define=DEMO=false \
+  --base-href "/<repo_name>/"
+```
+
+UI 層ではデモスポット（`isDemo=true`）をフィルタしません。距離判定は `LocationService` が行い、デモ時は距離 0m として表示されます。
+
+### GitHub Actions 例
+
+develop ブランチ（デモ ON）:
+
+```yaml
+- name: Build web
+  run: |
+    flutter build web --release \
+      --dart-define=DEMO=true \
+      --base-href "/${{ github.event.repository.name }}/"
+```
+
+main ブランチ（デモ OFF）:
+
+```yaml
+- name: Build web
+  run: |
+    flutter build web --release \
+      --dart-define=DEMO=false \
+      --base-href "/${{ github.event.repository.name }}/"
+```
+
 ## 使用技術
 
 - Flutter/Dart

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,10 +42,6 @@ android {
     }
 }
 
-dependencies {
-    implementation(project(":unityLibrary"))
-}
-
 flutter {
     source = "../.."
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,6 +42,10 @@ android {
     }
 }
 
+dependencies {
+    implementation(project(":unityLibrary"))
+}
+
 flutter {
     source = "../.."
 }

--- a/ios/File.txt
+++ b/ios/File.txt
@@ -1,0 +1,1 @@
+/Users/masahirotoma/niigata-flower-guide/ios/UnityLibrary/Unity-iPhone.xcodeproj

--- a/ios/File.txt
+++ b/ios/File.txt
@@ -1,1 +1,0 @@
-/Users/masahirotoma/niigata-flower-guide/ios/UnityLibrary/Unity-iPhone.xcodeproj

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  use_frameworks! :linkage => :static
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks! :linkage => :static
+  use_frameworks!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1286,6 +1286,8 @@ PODS:
     - PromisesObjC (~> 2.4)
   - FirebaseSharedSwift (11.15.0)
   - Flutter (1.0.0)
+  - gallery_saver (0.0.1):
+    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -1463,6 +1465,9 @@ PODS:
     - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -1470,12 +1475,14 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
+  - gallery_saver (from `.symlinks/plugins/gallery_saver/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -1517,6 +1524,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
+  gallery_saver:
+    :path: ".symlinks/plugins/gallery_saver/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_maps_flutter_ios:
@@ -1529,6 +1538,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  video_player_avfoundation:
+    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1550,6 +1561,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  gallery_saver: 1d68d1818df11b1afa84a97d1a530463753e92e3
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
@@ -1568,6 +1580,7 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
 
 PODFILE CHECKSUM: 97c361c6b27e660cace2ee8e493a5315b5f5bb08
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1286,6 +1286,8 @@ PODS:
     - PromisesObjC (~> 2.4)
   - FirebaseSharedSwift (11.15.0)
   - Flutter (1.0.0)
+  - flutter_unity_widget (4.0.0):
+    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -1458,6 +1460,9 @@ PODS:
   - RecaptchaInterop (101.0.0)
   - url_launcher_ios (0.0.1):
     - Flutter
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -1465,10 +1470,12 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
+  - flutter_unity_widget (from `.symlinks/plugins/flutter_unity_widget/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -1510,6 +1517,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
+  flutter_unity_widget:
+    :path: ".symlinks/plugins/flutter_unity_widget/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_maps_flutter_ios:
@@ -1518,6 +1527,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1539,6 +1550,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_unity_widget: 6383b30b50a9c9b320f5e728ef31568472cebc31
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
@@ -1555,7 +1567,8 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
-PODFILE CHECKSUM: 4688cfe749c7fad7eb43523418ee956a5b121af6
+PODFILE CHECKSUM: 97c361c6b27e660cace2ee8e493a5315b5f5bb08
 
 COCOAPODS: 1.16.2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1286,8 +1286,6 @@ PODS:
     - PromisesObjC (~> 2.4)
   - FirebaseSharedSwift (11.15.0)
   - Flutter (1.0.0)
-  - flutter_unity_widget (4.0.0):
-    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -1456,13 +1454,15 @@ PODS:
   - nanopb/encode (3.30910.0)
   - package_info_plus (0.4.5):
     - Flutter
-  - PromisesObjC (2.4.0)
-  - RecaptchaInterop (101.0.0)
-  - url_launcher_ios (0.0.1):
-    - Flutter
-  - webview_flutter_wkwebview (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - PromisesObjC (2.4.0)
+  - RecaptchaInterop (101.0.0)
+  - share_plus (0.0.1):
+    - Flutter
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -1470,12 +1470,12 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
-  - flutter_unity_widget (from `.symlinks/plugins/flutter_unity_widget/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -1517,18 +1517,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
-  flutter_unity_widget:
-    :path: ".symlinks/plugins/flutter_unity_widget/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_maps_flutter_ios:
     :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
-  webview_flutter_wkwebview:
-    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1550,7 +1550,6 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_unity_widget: 6383b30b50a9c9b320f5e728ef31568472cebc31
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
@@ -1564,10 +1563,11 @@ SPEC CHECKSUMS:
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: 97c361c6b27e660cace2ee8e493a5315b5f5bb08
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1286,8 +1286,6 @@ PODS:
     - PromisesObjC (~> 2.4)
   - FirebaseSharedSwift (11.15.0)
   - Flutter (1.0.0)
-  - flutter_unity_widget (4.0.0):
-    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -1460,9 +1458,6 @@ PODS:
   - RecaptchaInterop (101.0.0)
   - url_launcher_ios (0.0.1):
     - Flutter
-  - webview_flutter_wkwebview (0.0.1):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -1470,12 +1465,10 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
-  - flutter_unity_widget (from `.symlinks/plugins/flutter_unity_widget/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -1517,8 +1510,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
-  flutter_unity_widget:
-    :path: ".symlinks/plugins/flutter_unity_widget/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_maps_flutter_ios:
@@ -1527,8 +1518,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
-  webview_flutter_wkwebview:
-    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1550,7 +1539,6 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_unity_widget: 6383b30b50a9c9b320f5e728ef31568472cebc31
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
@@ -1567,8 +1555,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
-PODFILE CHECKSUM: 97c361c6b27e660cace2ee8e493a5315b5f5bb08
+PODFILE CHECKSUM: 4688cfe749c7fad7eb43523418ee956a5b121af6
 
 COCOAPODS: 1.16.2

--- a/ios/Pods/File.txt
+++ b/ios/Pods/File.txt
@@ -1,0 +1,1 @@
+/Users/masahirotoma/niigata-flower-guide/ios/UnityLibrary/Unity-iPhone.xcodeproj

--- a/ios/Pods/File.txt
+++ b/ios/Pods/File.txt
@@ -1,1 +1,0 @@
-/Users/masahirotoma/niigata-flower-guide/ios/UnityLibrary/Unity-iPhone.xcodeproj

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		F2C7EE612E6480C5002BB764 /* UnityFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2C7EE602E6480C5002BB764 /* UnityFramework.framework */; };
+		F2C7EE622E6480C5002BB764 /* UnityFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F2C7EE602E6480C5002BB764 /* UnityFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -26,15 +28,44 @@
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
 		};
+		F2C7EE7A2E6484AD002BB764 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 1D6058910D05DD3D006BFB54;
+			remoteInfo = "Unity-iPhone";
+		};
+		F2C7EE7C2E6484AD002BB764 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 5623C57317FDCB0800090B9E;
+			remoteInfo = "Unity-iPhone Tests";
+		};
+		F2C7EE7E2E6484AD002BB764 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9D25AB9D213FB47800354C27;
+			remoteInfo = UnityFramework;
+		};
+		F2C7EE802E6484AD002BB764 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7F4E05A02717216D00A2CBE4;
+			remoteInfo = GameAssembly;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
+		F2C7EE632E6480C5002BB764 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				F2C7EE622E6480C5002BB764 /* UnityFramework.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -64,6 +95,9 @@
 		A8829ED0081EC7CA5D269F23 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		AAB4F5B26EE08A8F51AA642B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		C46BD9095356893300234277 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2C7EE602E6480C5002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Unity-iPhone.xcodeproj"; path = "UnityLibrary/Unity-iPhone.xcodeproj"; sourceTree = "<group>"; };
 		F6F1E2945DAE85F7E282B05D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -81,6 +115,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02824888162EE5B1F84ADDB3 /* Pods_Runner.framework in Frameworks */,
+				F2C7EE612E6480C5002BB764 /* UnityFramework.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,6 +125,8 @@
 		2749816EEAE28EDFA6197415 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */,
+				F2C7EE602E6480C5002BB764 /* UnityFramework.framework */,
 				42908C6168E35697291987CC /* Pods_Runner.framework */,
 				945EC128F28A7404CDE2C38D /* Pods_RunnerTests.framework */,
 			);
@@ -131,6 +168,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
@@ -164,6 +202,17 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		F2C7EE742E6484AD002BB764 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F2C7EE7B2E6484AD002BB764 /* Unity-Target-New.app */,
+				F2C7EE7D2E6484AD002BB764 /* Unity-iPhone Tests.xctest */,
+				F2C7EE7F2E6484AD002BB764 /* UnityFramework.framework */,
+				F2C7EE812E6484AD002BB764 /* libGameAssembly.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -195,10 +244,9 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
-				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				F8D12E9ED51C06DD24E64642 /* [CP] Embed Pods Frameworks */,
 				6B150C1BA2B74BFFA8815E78 /* [CP] Copy Pods Resources */,
+				F2C7EE632E6480C5002BB764 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -240,6 +288,12 @@
 			mainGroup = 97C146E51CF9000F007C117D;
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = F2C7EE742E6484AD002BB764 /* Products */;
+					ProjectRef = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
@@ -247,6 +301,38 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		F2C7EE7B2E6484AD002BB764 /* Unity-Target-New.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			name = "Unity-Target-New.app";
+			path = NiigataFlowerGuide.app;
+			remoteRef = F2C7EE7A2E6484AD002BB764 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F2C7EE7D2E6484AD002BB764 /* Unity-iPhone Tests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "Unity-iPhone Tests.xctest";
+			remoteRef = F2C7EE7C2E6484AD002BB764 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F2C7EE7F2E6484AD002BB764 /* UnityFramework.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = UnityFramework.framework;
+			remoteRef = F2C7EE7E2E6484AD002BB764 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F2C7EE812E6484AD002BB764 /* libGameAssembly.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libGameAssembly.a;
+			remoteRef = F2C7EE802E6484AD002BB764 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		331C807F294A63A400263BE5 /* Resources */ = {
@@ -294,9 +380,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -360,23 +450,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F8D12E9ED51C06DD24E64642 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,14 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		2051EBB8E3166A6ECDD46E22 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63048FB93FD2DD5383A007E8 /* Pods_RunnerTests.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		6687CAFFA45CF366F82B63AC /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B861C195D4834009EF94DBA /* Pods_RunnerTests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		966BBF14EF03AAF003669845 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB31DB10F92B74855215D4EE /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		E16C06A0A2213E5C0414A152 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30535A28B8CEF730ADA0ED7B /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,19 +70,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B2D4022106A769991C72A9B /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		30535A28B8CEF730ADA0ED7B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3B861C195D4834009EF94DBA /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		455493C69F1203C5E4CBA77C /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		4CA360CF016DC057B126E6E7 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		63048FB93FD2DD5383A007E8 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FB5D563BB3F1BFD7C0CF6F5 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		7D504CDBD0FD6D5FEA3B14D0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		909ABBD234BDCC553E5C1EC5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -90,12 +89,13 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B240F26319C1FFF83316BDBD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		EAD913554B5CB55C43041DB3 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		9A869790AB2F66E4F37A3403 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		CB31DB10F92B74855215D4EE /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC541E0FF810F8181EE9BD28 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F08D1351014DFBD6D176EE59 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2C7EE602E6480C5002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Unity-iPhone.xcodeproj"; path = "UnityLibrary/Unity-iPhone.xcodeproj"; sourceTree = "<group>"; };
-		F3E3637E5B66EE29DE099BD4 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,7 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6687CAFFA45CF366F82B63AC /* Pods_RunnerTests.framework in Frameworks */,
+				2051EBB8E3166A6ECDD46E22 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -111,7 +111,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E16C06A0A2213E5C0414A152 /* Pods_Runner.framework in Frameworks */,
+				966BBF14EF03AAF003669845 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,8 +123,8 @@
 			children = (
 				F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */,
 				F2C7EE602E6480C5002BB764 /* UnityFramework.framework */,
-				30535A28B8CEF730ADA0ED7B /* Pods_Runner.framework */,
-				3B861C195D4834009EF94DBA /* Pods_RunnerTests.framework */,
+				CB31DB10F92B74855215D4EE /* Pods_Runner.framework */,
+				63048FB93FD2DD5383A007E8 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -140,12 +140,12 @@
 		575E6A9D31E04177D53D0A85 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				B240F26319C1FFF83316BDBD /* Pods-Runner.debug.xcconfig */,
-				EAD913554B5CB55C43041DB3 /* Pods-Runner.release.xcconfig */,
-				F3E3637E5B66EE29DE099BD4 /* Pods-Runner.profile.xcconfig */,
-				7D504CDBD0FD6D5FEA3B14D0 /* Pods-RunnerTests.debug.xcconfig */,
-				455493C69F1203C5E4CBA77C /* Pods-RunnerTests.release.xcconfig */,
-				909ABBD234BDCC553E5C1EC5 /* Pods-RunnerTests.profile.xcconfig */,
+				9A869790AB2F66E4F37A3403 /* Pods-Runner.debug.xcconfig */,
+				DC541E0FF810F8181EE9BD28 /* Pods-Runner.release.xcconfig */,
+				4CA360CF016DC057B126E6E7 /* Pods-Runner.profile.xcconfig */,
+				0B2D4022106A769991C72A9B /* Pods-RunnerTests.debug.xcconfig */,
+				6FB5D563BB3F1BFD7C0CF6F5 /* Pods-RunnerTests.release.xcconfig */,
+				F08D1351014DFBD6D176EE59 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -216,7 +216,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				ECCDB5AC11A446F0A33AB820 /* [CP] Check Pods Manifest.lock */,
+				E554B9516837CED200F7F8FE /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				2CF08BA87CAEAF4281387B1E /* Frameworks */,
@@ -235,14 +235,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				E9F8D68574FD49BB39F54883 /* [CP] Check Pods Manifest.lock */,
+				AE6899992C91FD35DDEF7019 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				F2C7EE632E6480C5002BB764 /* Embed Frameworks */,
-				3E6EA616856B89B57471F2B0 /* [CP] Copy Pods Resources */,
+				0F3469ACE137716978B8CEFE /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -352,23 +352,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		3E6EA616856B89B57471F2B0 /* [CP] Copy Pods Resources */ = {
+		0F3469ACE137716978B8CEFE /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -389,6 +373,22 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -404,7 +404,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		E9F8D68574FD49BB39F54883 /* [CP] Check Pods Manifest.lock */ = {
+		AE6899992C91FD35DDEF7019 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -426,7 +426,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		ECCDB5AC11A446F0A33AB820 /* [CP] Check Pods Manifest.lock */ = {
+		E554B9516837CED200F7F8FE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -672,7 +672,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7D504CDBD0FD6D5FEA3B14D0 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 0B2D4022106A769991C72A9B /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -690,7 +690,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 455493C69F1203C5E4CBA77C /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 6FB5D563BB3F1BFD7C0CF6F5 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -706,7 +706,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 909ABBD234BDCC553E5C1EC5 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = F08D1351014DFBD6D176EE59 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,17 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02824888162EE5B1F84ADDB3 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42908C6168E35697291987CC /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		251692AB7BA4BC8A5EE570A4 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 945EC128F28A7404CDE2C38D /* Pods_RunnerTests.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		6687CAFFA45CF366F82B63AC /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B861C195D4834009EF94DBA /* Pods_RunnerTests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		F2C7EE612E6480C5002BB764 /* UnityFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2C7EE602E6480C5002BB764 /* UnityFramework.framework */; };
-		F2C7EE622E6480C5002BB764 /* UnityFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F2C7EE602E6480C5002BB764 /* UnityFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E16C06A0A2213E5C0414A152 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30535A28B8CEF730ADA0ED7B /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,7 +63,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F2C7EE622E6480C5002BB764 /* UnityFramework.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -75,16 +72,17 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		30535A28B8CEF730ADA0ED7B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		42908C6168E35697291987CC /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4BABD5678EC9D6448EC77C6E /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5A5351BB16349E97122B7ACA /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		3B861C195D4834009EF94DBA /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		455493C69F1203C5E4CBA77C /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		945EC128F28A7404CDE2C38D /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D504CDBD0FD6D5FEA3B14D0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		909ABBD234BDCC553E5C1EC5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -92,13 +90,12 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A8829ED0081EC7CA5D269F23 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		AAB4F5B26EE08A8F51AA642B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
-		C46BD9095356893300234277 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		B240F26319C1FFF83316BDBD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		EAD913554B5CB55C43041DB3 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2C7EE602E6480C5002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Unity-iPhone.xcodeproj"; path = "UnityLibrary/Unity-iPhone.xcodeproj"; sourceTree = "<group>"; };
-		F6F1E2945DAE85F7E282B05D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		F3E3637E5B66EE29DE099BD4 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,7 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				251692AB7BA4BC8A5EE570A4 /* Pods_RunnerTests.framework in Frameworks */,
+				6687CAFFA45CF366F82B63AC /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,8 +111,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				02824888162EE5B1F84ADDB3 /* Pods_Runner.framework in Frameworks */,
-				F2C7EE612E6480C5002BB764 /* UnityFramework.framework in Frameworks */,
+				E16C06A0A2213E5C0414A152 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,8 +123,8 @@
 			children = (
 				F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */,
 				F2C7EE602E6480C5002BB764 /* UnityFramework.framework */,
-				42908C6168E35697291987CC /* Pods_Runner.framework */,
-				945EC128F28A7404CDE2C38D /* Pods_RunnerTests.framework */,
+				30535A28B8CEF730ADA0ED7B /* Pods_Runner.framework */,
+				3B861C195D4834009EF94DBA /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -144,12 +140,12 @@
 		575E6A9D31E04177D53D0A85 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A8829ED0081EC7CA5D269F23 /* Pods-Runner.debug.xcconfig */,
-				C46BD9095356893300234277 /* Pods-Runner.release.xcconfig */,
-				5A5351BB16349E97122B7ACA /* Pods-Runner.profile.xcconfig */,
-				4BABD5678EC9D6448EC77C6E /* Pods-RunnerTests.debug.xcconfig */,
-				AAB4F5B26EE08A8F51AA642B /* Pods-RunnerTests.release.xcconfig */,
-				F6F1E2945DAE85F7E282B05D /* Pods-RunnerTests.profile.xcconfig */,
+				B240F26319C1FFF83316BDBD /* Pods-Runner.debug.xcconfig */,
+				EAD913554B5CB55C43041DB3 /* Pods-Runner.release.xcconfig */,
+				F3E3637E5B66EE29DE099BD4 /* Pods-Runner.profile.xcconfig */,
+				7D504CDBD0FD6D5FEA3B14D0 /* Pods-RunnerTests.debug.xcconfig */,
+				455493C69F1203C5E4CBA77C /* Pods-RunnerTests.release.xcconfig */,
+				909ABBD234BDCC553E5C1EC5 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -220,7 +216,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				A681948B7DEBF31DA92605BB /* [CP] Check Pods Manifest.lock */,
+				ECCDB5AC11A446F0A33AB820 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				2CF08BA87CAEAF4281387B1E /* Frameworks */,
@@ -239,14 +235,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				B77CA925C6340649364CB447 /* [CP] Check Pods Manifest.lock */,
+				E9F8D68574FD49BB39F54883 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				6B150C1BA2B74BFFA8815E78 /* [CP] Copy Pods Resources */,
 				F2C7EE632E6480C5002BB764 /* Embed Frameworks */,
+				3E6EA616856B89B57471F2B0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -372,7 +368,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		6B150C1BA2B74BFFA8815E78 /* [CP] Copy Pods Resources */ = {
+		3E6EA616856B89B57471F2B0 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -408,29 +404,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		A681948B7DEBF31DA92605BB /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B77CA925C6340649364CB447 /* [CP] Check Pods Manifest.lock */ = {
+		E9F8D68574FD49BB39F54883 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -446,6 +420,28 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ECCDB5AC11A446F0A33AB820 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -676,7 +672,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4BABD5678EC9D6448EC77C6E /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 7D504CDBD0FD6D5FEA3B14D0 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -694,7 +690,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AAB4F5B26EE08A8F51AA642B /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 455493C69F1203C5E4CBA77C /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -710,7 +706,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F6F1E2945DAE85F7E282B05D /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 909ABBD234BDCC553E5C1EC5 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		F2C7EE612E6480C5002BB764 /* UnityFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2C7EE602E6480C5002BB764 /* UnityFramework.framework */; };
-		F2C7EE622E6480C5002BB764 /* UnityFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F2C7EE602E6480C5002BB764 /* UnityFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,44 +26,15 @@
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
 		};
-		F2C7EE7A2E6484AD002BB764 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 1D6058910D05DD3D006BFB54;
-			remoteInfo = "Unity-iPhone";
-		};
-		F2C7EE7C2E6484AD002BB764 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5623C57317FDCB0800090B9E;
-			remoteInfo = "Unity-iPhone Tests";
-		};
-		F2C7EE7E2E6484AD002BB764 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9D25AB9D213FB47800354C27;
-			remoteInfo = UnityFramework;
-		};
-		F2C7EE802E6484AD002BB764 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 7F4E05A02717216D00A2CBE4;
-			remoteInfo = GameAssembly;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		F2C7EE632E6480C5002BB764 /* Embed Frameworks */ = {
+		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F2C7EE622E6480C5002BB764 /* UnityFramework.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -95,9 +64,6 @@
 		A8829ED0081EC7CA5D269F23 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		AAB4F5B26EE08A8F51AA642B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		C46BD9095356893300234277 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F2C7EE602E6480C5002BB764 /* UnityFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = UnityFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Unity-iPhone.xcodeproj"; path = "UnityLibrary/Unity-iPhone.xcodeproj"; sourceTree = "<group>"; };
 		F6F1E2945DAE85F7E282B05D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -115,7 +81,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				02824888162EE5B1F84ADDB3 /* Pods_Runner.framework in Frameworks */,
-				F2C7EE612E6480C5002BB764 /* UnityFramework.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,8 +90,6 @@
 		2749816EEAE28EDFA6197415 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F2C7EE5D2E64779C002BB764 /* UnityFramework.framework */,
-				F2C7EE602E6480C5002BB764 /* UnityFramework.framework */,
 				42908C6168E35697291987CC /* Pods_Runner.framework */,
 				945EC128F28A7404CDE2C38D /* Pods_RunnerTests.framework */,
 			);
@@ -168,7 +131,6 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
-				F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
@@ -202,17 +164,6 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
-		F2C7EE742E6484AD002BB764 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F2C7EE7B2E6484AD002BB764 /* Unity-Target-New.app */,
-				F2C7EE7D2E6484AD002BB764 /* Unity-iPhone Tests.xctest */,
-				F2C7EE7F2E6484AD002BB764 /* UnityFramework.framework */,
-				F2C7EE812E6484AD002BB764 /* libGameAssembly.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -244,9 +195,10 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
+				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				F8D12E9ED51C06DD24E64642 /* [CP] Embed Pods Frameworks */,
 				6B150C1BA2B74BFFA8815E78 /* [CP] Copy Pods Resources */,
-				F2C7EE632E6480C5002BB764 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -288,12 +240,6 @@
 			mainGroup = 97C146E51CF9000F007C117D;
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = F2C7EE742E6484AD002BB764 /* Products */;
-					ProjectRef = F2C7EE732E6484AD002BB764 /* Unity-iPhone.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
@@ -301,38 +247,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		F2C7EE7B2E6484AD002BB764 /* Unity-Target-New.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			name = "Unity-Target-New.app";
-			path = NiigataFlowerGuide.app;
-			remoteRef = F2C7EE7A2E6484AD002BB764 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F2C7EE7D2E6484AD002BB764 /* Unity-iPhone Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "Unity-iPhone Tests.xctest";
-			remoteRef = F2C7EE7C2E6484AD002BB764 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F2C7EE7F2E6484AD002BB764 /* UnityFramework.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = UnityFramework.framework;
-			remoteRef = F2C7EE7E2E6484AD002BB764 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F2C7EE812E6484AD002BB764 /* libGameAssembly.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libGameAssembly.a;
-			remoteRef = F2C7EE802E6484AD002BB764 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		331C807F294A63A400263BE5 /* Resources */ = {
@@ -380,13 +294,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -450,6 +360,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F8D12E9ED51C06DD24E64642 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,6 +49,8 @@
 	<string>AR 機能のためにカメラを使用します。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>現在地を地図に表示するために位置情報を利用します。</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>プレビュー動画を写真ライブラリに保存するために使用します。</string>
 	<!-- Google Maps APIキー設定（設定ファイルから参照） -->
 	<key>GMSApiKey</key>
 	<string>$(GOOGLE_MAPS_API_KEY)</string>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,8 +45,6 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>AR 機能のためにカメラを使用します。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>現在地を地図に表示するために位置情報を利用します。</string>
 	<!-- Google Maps APIキー設定（設定ファイルから参照） -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,6 +45,8 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>AR 機能のためにカメラを使用します。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>現在地を地図に表示するために位置情報を利用します。</string>
 	<!-- Google Maps APIキー設定（設定ファイルから参照） -->

--- a/lib/ar/ar_preview_launcher.dart
+++ b/lib/ar/ar_preview_launcher.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../common/video_source.dart';
+import 'ar_preview_sheet.dart';
+
+class FlowerVideoRegistry {
+  static final Map<String, VideoSource> _map = {
+    // アジサイ
+    'hydrangea': const VideoSource.asset('assets/videos/hydrangea.mp4'),
+    // チューリップ
+    'tulip': const VideoSource.asset('assets/videos/tulip.mp4'),
+    // 桜
+    'sakura': const VideoSource.asset('assets/videos/sakura.mp4'),
+    // 菜の花
+    'rapeblossoms': const VideoSource.asset('assets/videos/rapeblossoms.mp4'),
+    // ハス
+    'lotus': const VideoSource.asset('assets/videos/lotus.mp4'),
+  };
+
+  static VideoSource? resolve(String flowerId) => _map[flowerId];
+}
+
+class ArPreviewLauncher {
+  final void Function(String message)? onMissingVideo;
+  final Color? saveButtonColor;
+  final Color? saveButtonForegroundColor;
+
+  ArPreviewLauncher({this.onMissingVideo, this.saveButtonColor = const Color(0xFF4CAF50), this.saveButtonForegroundColor = Colors.white});
+
+  Future<void> show(BuildContext context, {required String flowerId}) async {
+    final src = FlowerVideoRegistry.resolve(flowerId);
+    if (src == null) {
+      onMissingVideo?.call('このスポットにはプレビュー動画が未登録です。');
+      return;
+    }
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => ArPreviewSheet(
+        source: src,
+        showStartButton: false,
+        saveButtonColor: saveButtonColor ?? Colors.black54,
+        saveButtonForegroundColor: saveButtonForegroundColor ?? Colors.white,
+      ),
+    );
+  }
+
+  Future<void> pickAndShow(BuildContext context) async {
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: false,
+      useSafeArea: true,
+      builder: (ctx) {
+        Widget buildItem(String id, String label, IconData icon) {
+          return ListTile(
+            leading: Icon(icon),
+            title: Text(label),
+            onTap: () => Navigator.of(ctx).pop(id),
+          );
+        }
+
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Padding(
+                padding: EdgeInsets.all(12),
+                child: Text('花を選択', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              ),
+              buildItem('tulip', 'チューリップ', Icons.local_florist),
+              buildItem('hydrangea', 'アジサイ', Icons.local_florist),
+              buildItem('sakura', '桜', Icons.local_florist),
+              buildItem('rapeblossoms', '菜の花', Icons.local_florist),
+              buildItem('lotus', 'ハス', Icons.local_florist),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (selected == null) return;
+    await show(context, flowerId: selected);
+  }
+}
+
+

--- a/lib/ar/ar_preview_sheet.dart
+++ b/lib/ar/ar_preview_sheet.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+import '../common/video_source.dart';
+import 'package:gallery_saver/gallery_saver.dart';
+
+class ArPreviewSheet extends StatefulWidget {
+  final VideoSource source;
+  final String title;
+  final bool showStartButton;
+  final VoidCallback? onStartAr;
+  final Color saveButtonColor;
+  final Color saveButtonForegroundColor;
+
+  const ArPreviewSheet({
+    super.key,
+    required this.source,
+    this.title = 'ARプレビュー',
+    this.showStartButton = false,
+    this.onStartAr,
+    this.saveButtonColor = const Color(0xFF4CAF50),
+    this.saveButtonForegroundColor = Colors.white,
+  });
+
+  @override
+  State<ArPreviewSheet> createState() => _ArPreviewSheetState();
+}
+
+class _ArPreviewSheetState extends State<ArPreviewSheet> {
+  late final VideoPlayerController _controller;
+  bool _ready = false;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = switch (widget.source.kind) {
+      VideoKind.asset => VideoPlayerController.asset(widget.source.pathOrUrl),
+      VideoKind.network => VideoPlayerController.networkUrl(Uri.parse(widget.source.pathOrUrl)),
+    };
+    _controller
+      ..setLooping(true)
+      ..initialize().then((_) {
+        if (!mounted) return;
+        setState(() => _ready = true);
+        _controller.play();
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ratio = _ready ? _controller.value.aspectRatio : 16 / 9;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(widget.title, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Stack(
+              children: [
+                AspectRatio(
+                  aspectRatio: ratio,
+                  child: _ready
+                      ? VideoPlayer(_controller)
+                      : const Center(child: CircularProgressIndicator()),
+                ),
+                Positioned(
+                  right: 8,
+                  bottom: 8,
+                  child: FilledButton.icon(
+                    style: FilledButton.styleFrom(
+                      backgroundColor: widget.saveButtonColor,
+                      foregroundColor: widget.saveButtonForegroundColor,
+                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                      minimumSize: const Size(0, 36),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    ),
+                    icon: _saving
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                          )
+                        : const Icon(Icons.download, size: 18),
+                    label: Text(_saving ? '保存中…' : '保存する', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                    onPressed: _saving
+                        ? null
+                        : () async {
+                            setState(() => _saving = true);
+                            try {
+                              switch (widget.source.kind) {
+                                case VideoKind.asset:
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('アセット動画の保存は現在未対応です')),
+                                  );
+                                  break;
+                                case VideoKind.network:
+                                  final ok = await GallerySaver.saveVideo(widget.source.pathOrUrl);
+                                  if (ok == true) {
+                                    if (!mounted) return;
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(content: Text('保存しました')),
+                                    );
+                                  } else {
+                                    if (!mounted) return;
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(content: Text('保存に失敗しました')),
+                                    );
+                                  }
+                                  break;
+                              }
+                            } finally {
+                              if (mounted) setState(() => _saving = false);
+                            }
+                          },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).maybePop(),
+                  child: const Text('閉じる'),
+                ),
+                const Spacer(),
+                if (widget.showStartButton && widget.onStartAr != null)
+                  FilledButton(
+                    onPressed: () {
+                      Navigator.of(context).maybePop();
+                      widget.onStartAr!.call();
+                    },
+                    child: const Text('ARを起動'),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/lib/common/video_source.dart
+++ b/lib/common/video_source.dart
@@ -1,0 +1,11 @@
+enum VideoKind { asset, network }
+
+class VideoSource {
+  final VideoKind kind;
+  final String pathOrUrl;
+
+  const VideoSource.asset(this.pathOrUrl) : kind = VideoKind.asset;
+  const VideoSource.network(this.pathOrUrl) : kind = VideoKind.network;
+}
+
+

--- a/lib/data/spots.dart
+++ b/lib/data/spots.dart
@@ -288,7 +288,7 @@ const List<Spot> spots = [
   ),
   Spot(
     id: 'gomadoyama-001',
-    title: '護摩堂山アジサイ園',
+    title: '護摩堂山あじさい園',
     location: '新潟県田上町田上（護摩堂山山頂付近）',
     image: 'assets/photos/ajisai1.JPG',
     images: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'screens/signup_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/profileedit_screen.dart';
 import 'screens/stamps_collection_screen.dart';
-import 'screens/unity_ar_screen.dart';  // Unity連携を一旦保留
+// import 'screens/unity_ar_screen.dart';  // Unity連携を一旦保留
 
 // デモ設定クラス
 class _DemoConfig {
@@ -151,7 +151,7 @@ class NiigataFlowerGuide extends StatelessWidget {
               '/profile': (context) => const ProfileScreen(),
               '/profileedit': (context) => const ProfileEditScreen(),
               '/collection': (context) => const StampCollectionScreen(),
-              '/ar': (context) => UnityARScreen(),
+              // '/ar': (context) => UnityARScreen(),  // Unity連携を一旦保留
             },
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ import 'screens/signup_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/profileedit_screen.dart';
 import 'screens/stamps_collection_screen.dart';
-// import 'screens/unity_ar_screen.dart';  // Unity連携を一旦保留
+import 'screens/unity_ar_screen.dart';  // Unity連携を一旦保留
 
 // デモ設定クラス
 class _DemoConfig {
@@ -151,7 +151,7 @@ class NiigataFlowerGuide extends StatelessWidget {
               '/profile': (context) => const ProfileScreen(),
               '/profileedit': (context) => const ProfileEditScreen(),
               '/collection': (context) => const StampCollectionScreen(),
-              // '/ar': (context) => UnityARScreen(),  // Unity連携を一旦保留
+              '/ar': (context) => UnityARScreen(),
             },
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,8 @@ import 'screens/signup_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/profileedit_screen.dart';
 import 'screens/stamps_collection_screen.dart';
-import 'screens/unity_ar_screen.dart';  // Unity連携を一旦保留
+// import 'screens/unity_ar_screen.dart';  // Unity連携（再有効化時に戻す）
+import 'screens/unity_ar_screen_stub.dart'; // 一時スタブ画面（Unity無効化中）
 
 // デモ設定クラス
 class _DemoConfig {
@@ -151,7 +152,8 @@ class NiigataFlowerGuide extends StatelessWidget {
               '/profile': (context) => const ProfileScreen(),
               '/profileedit': (context) => const ProfileEditScreen(),
               '/collection': (context) => const StampCollectionScreen(),
-              '/ar': (context) => UnityARScreen(),
+              // '/ar': (context) => UnityARScreen(), // Unity連携（再有効化時に戻す）
+              '/ar': (context) => const UnityArScreen(), // 一時スタブ
             },
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,8 +73,8 @@ Future<void> main() async {
   try {
     WidgetsFlutterBinding.ensureInitialized();
     
-    // デモモードでのジオロケーション偽装設定
-    if (kDebugMode && _DemoConfig.demoMode) {
+    // デモモードでのジオロケーション偽装設定（Release でも DEMO=true 指定で有効）
+    if (_DemoConfig.demoMode) {
       // 新潟県の中心付近を偽装位置として設定
       final fakePosition = Position(
         latitude: 37.9026,

--- a/lib/providers/stamp_provider.dart
+++ b/lib/providers/stamp_provider.dart
@@ -83,7 +83,7 @@ class StampProvider with ChangeNotifier {
   // デモモード用の匿名認証
   Future<void> _handleAnonymousAuth() async {
     try {
-      if (kDebugMode || _DemoConfig.demoMode) {
+      if (_DemoConfig.demoMode) {
         // デバッグモードまたはデモモードでは自動的に匿名認証
         await FirebaseAuth.instance.signInAnonymously();
         print('🧪 StampProvider: デモ用匿名認証を実行しました');
@@ -176,8 +176,8 @@ class StampProvider with ChangeNotifier {
         return false;
       }
 
-      // デモスポットまたはデバッグモードの場合
-      if (spot.isDemo || (kDebugMode && _DemoConfig.demoMode)) {
+      // デモスポットまたは demoMode=true の場合
+      if (spot.isDemo || _DemoConfig.demoMode) {
         print('🧪 デモスポット処理: ${spot.title}');
         
         // デモスポットでは位置情報を偽装

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -85,9 +85,7 @@ class HomeScreen extends StatelessWidget {
                       iconSize: 40,
                       fontSize: 14,
                       padding: 12,
-                      onTap: () => ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('ARカメラ機能は開発中です')),
-                      ),
+                      onTap: () => Navigator.pushNamed(context, '/ar'),
                     ),
                   ],
                 ),
@@ -117,9 +115,7 @@ class HomeScreen extends StatelessWidget {
               Navigator.pushNamed(context, '/map');
               break;
             case 2:
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('ARカメラ機能は開発中です')),
-              );
+              Navigator.pushNamed(context, '/ar');
               break;
             case 3:
               Navigator.pushNamed(context, '/collection');

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -85,7 +85,9 @@ class HomeScreen extends StatelessWidget {
                       iconSize: 40,
                       fontSize: 14,
                       padding: 12,
-                      onTap: () => Navigator.pushNamed(context, '/ar'),
+                      onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('ARカメラ機能は開発中です')),
+                      ),
                     ),
                   ],
                 ),
@@ -115,7 +117,9 @@ class HomeScreen extends StatelessWidget {
               Navigator.pushNamed(context, '/map');
               break;
             case 2:
-              Navigator.pushNamed(context, '/ar');
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('ARカメラ機能は開発中です')),
+              );
               break;
             case 3:
               Navigator.pushNamed(context, '/collection');

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -52,26 +52,34 @@ class HomeScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            // タイトル
-            Text(
-              'Niigata 花図鑑',
-              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                    color: const Color(0xFF3E5C40),
-                    fontWeight: FontWeight.bold,
+            // タイトル＋サブタイトル＋グリッド（全体で左右16を共有し、左端を完全に揃える）
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Niigata 花図鑑',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          color: const Color(0xFF3E5C40),
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
-            ),
-            const SizedBox(height: 16),
-              // グリッド
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: GridView.count(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  crossAxisCount: 2,
-                  mainAxisSpacing: 12,
-                  crossAxisSpacing: 12,
-                  childAspectRatio: 1,
-                  children: [
+                  const SizedBox(height: 4),
+                  const Text(
+                    '花をきっかけに、新潟の魅力を見つけよう。',
+                    style: TextStyle(color: Color(0xFF3E5C40)),
+                  ),
+                  const SizedBox(height: 16),
+                  // グリッド
+                  GridView.count(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    crossAxisCount: 2,
+                    mainAxisSpacing: 12,
+                    crossAxisSpacing: 12,
+                    childAspectRatio: 1,
+                    children: [
                     IconTile(
                       icon: 'map_icon.png',
                       label: 'マップ',
@@ -108,10 +116,12 @@ class HomeScreen extends StatelessWidget {
                       padding: 12,
                       onTap: _openArPicker,
                     ),
-                  ],
-                ),
+                    ],
+                  ),
+              ],
               ),
-              const SizedBox(height: 16),
+            ),
+            const SizedBox(height: 16),
               
               // 近くのスポット情報
               Padding(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,12 +2,33 @@ import 'package:flutter/material.dart';
 import '../widgets/icon_tile.dart';
 import '../widgets/nearby_spots_widget.dart';
 import 'map_screen.dart';
+import '../ar/ar_preview_launcher.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    Future<void> _openArPreview(String flowerId) async {
+      final launcher = ArPreviewLauncher(
+        onMissingVideo: (msg) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(msg)),
+          );
+        },
+      );
+      await launcher.show(context, flowerId: flowerId);
+    }
+    Future<void> _openArPicker() async {
+      final launcher = ArPreviewLauncher(
+        onMissingVideo: (msg) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(msg)),
+          );
+        },
+      );
+      await launcher.pickAndShow(context);
+    }
     return Scaffold(
       body: SafeArea(
         child: SingleChildScrollView(
@@ -85,7 +106,7 @@ class HomeScreen extends StatelessWidget {
                       iconSize: 40,
                       fontSize: 14,
                       padding: 12,
-                      onTap: () => Navigator.pushNamed(context, '/ar'),
+                      onTap: _openArPicker,
                     ),
                   ],
                 ),
@@ -115,7 +136,7 @@ class HomeScreen extends StatelessWidget {
               Navigator.pushNamed(context, '/map');
               break;
             case 2:
-              Navigator.pushNamed(context, '/ar');
+              _openArPicker();
               break;
             case 3:
               Navigator.pushNamed(context, '/collection');

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -122,7 +122,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                             const SizedBox(height: 8),
                             const Text(
-                              '花をきっかけに、新潟の魅力を発見する',
+                              '花をきっかけに、新潟の魅力を見つけよう。',
                               style: TextStyle(
                                 fontSize: 14,
                                 color: Color(0xFF3A5A40),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -421,9 +421,7 @@ class _MapScreenState extends State<MapScreen> {
         unselectedItemColor: Colors.grey,
         onTap: (i) {
           if (i == 0) Navigator.pushReplacementNamed(context, '/');
-          if (i == 2) ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('ARカメラ機能は開発中です')),
-          );
+          if (i == 2) Navigator.pushReplacementNamed(context, '/');
           if (i == 3) Navigator.pushNamed(context, '/collection');
           if (i == 4) Navigator.pushNamed(context, '/profile');
         },

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -24,6 +24,8 @@ class _MapScreenState extends State<MapScreen> {
   GoogleMapController? _mapController;
   final Set<Marker> _markers = {};
   bool _isBottomSheetOpen = false;
+  // 現在地表示フラグ（暫定的に非表示にする場合は false のまま）
+  final bool _showUserLocation = false;
 
   // 検索機能の状態管理
   final TextEditingController _searchController = TextEditingController();
@@ -251,15 +253,15 @@ class _MapScreenState extends State<MapScreen> {
                           onMapCreated: (controller) {
                             _mapController = controller;
                           },
-                          myLocationEnabled: _currentPosition != null,
-                          myLocationButtonEnabled: true,
+                          myLocationEnabled: _showUserLocation && _currentPosition != null,
+                          myLocationButtonEnabled: _showUserLocation,
                           zoomGesturesEnabled: !_isBottomSheetOpen,
                           scrollGesturesEnabled: !_isBottomSheetOpen,
                           tiltGesturesEnabled: !_isBottomSheetOpen,
                           rotateGesturesEnabled: !_isBottomSheetOpen,
                           markers: {
                             ..._markers,
-                            if (_currentPosition != null)
+                            if (_showUserLocation && _currentPosition != null)
                               Marker(
                                 markerId: const MarkerId('currentLocation'),
                                 position: _currentPosition!,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -308,9 +308,7 @@ class ProfileScreen extends StatelessWidget {
               Navigator.pushNamed(context, '/map');
               break;
             case 2:
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('ARカメラ機能は開発中です')),
-              );
+              Navigator.pushReplacementNamed(context, '/');
               break;
             case 3:
               Navigator.pushNamed(context, '/collection');

--- a/lib/screens/profileedit_screen.dart
+++ b/lib/screens/profileedit_screen.dart
@@ -116,9 +116,7 @@ class ProfileEditScreen extends StatelessWidget {
               Navigator.pushNamed(context, '/map');
               break;
             case 2:
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('ARカメラ機能は開発中です')),
-              );
+              Navigator.pushReplacementNamed(context, '/');
               break;
             case 4:
               Navigator.pop(context);

--- a/lib/screens/stamps_collection_screen.dart
+++ b/lib/screens/stamps_collection_screen.dart
@@ -98,8 +98,8 @@ class StampCollectionScreen extends StatelessWidget {
                         );
                       }
 
-                      // デモスポットを除いた実際のスポット一覧を取得
-                      final actualSpots = spots.where((spot) => !spot.isDemo).toList();
+                      // デモ／実スポットをまとめて受け取り、距離判定結果で絞り込む
+                      final actualSpots = spots;
                       final stamps = stampProvider.stamps;
 
                       return Padding(
@@ -187,12 +187,9 @@ class StampCollectionScreen extends StatelessWidget {
                 // 進捗表示とボトムナビゲーション
                 Consumer<StampProvider>(
                   builder: (context, stampProvider, child) {
-                    // 実際のスポット数（デモスポット除外）
-                    final total = spots.where((spot) => !spot.isDemo).length;
-                    final collectedCount = stampProvider.stamps
-                        .where((stamp) => !spots.any((spot) => 
-                            spot.isDemo && spot.title == stamp.spotTitle))
-                        .length;
+                    // 総スポット数（デモ含む）。表示は LocationService の結果に依存
+                    final total = spots.length;
+                    final collectedCount = stampProvider.stamps.length;
 
                     return Column(
                       children: [

--- a/lib/screens/stamps_collection_screen.dart
+++ b/lib/screens/stamps_collection_screen.dart
@@ -253,7 +253,7 @@ class StampCollectionScreen extends StatelessWidget {
                         Navigator.pushNamed(context, '/map');
                         break;
                       case 2:
-                        Navigator.pushNamed(context, '/ar');
+                        Navigator.pushNamed(context, '/');
                         break;
                       case 4:
                         Navigator.pushNamed(context, '/profile');

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:geolocator/geolocator.dart';
 import '../models/spot.dart';
 
@@ -72,8 +71,8 @@ class LocationService {
 
   // ユーザーがスポットの近くにいるかチェック
   static Future<bool> isNearSpot(Spot spot) async {
-    // デモスポット または デバッグモードでは常にtrue
-    if (spot.isDemo || (kDebugMode && _DemoConfig.demoMode)) {
+    // デモスポット または demoMode=true なら常に true（Release でも有効）
+    if (spot.isDemo || _DemoConfig.demoMode) {
       return true;
     }
 
@@ -135,8 +134,8 @@ class LocationService {
     List<Map<String, dynamic>> nearbySpots = [];
 
     for (Spot spot in spots) {
-      // デモスポット または デバッグモードの場合
-      if (spot.isDemo || (kDebugMode && _DemoConfig.demoMode)) {
+      // デモスポット または demoMode=true の場合は常に距離0mとして扱う
+      if (spot.isDemo || _DemoConfig.demoMode) {
         nearbySpots.add({
           'spot': spot,
           'distance': 0.0, // デモスポットは距離0として扱う

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import package_info_plus
 import path_provider_foundation
 import share_plus
 import url_launcher_macos
+import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -25,4 +26,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,7 +14,6 @@ import package_info_plus
 import path_provider_foundation
 import share_plus
 import url_launcher_macos
-import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -26,5 +25,4 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
-  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import package_info_plus
 import path_provider_foundation
 import share_plus
 import url_launcher_macos
+import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -25,4 +26,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/niigata-flower-guide-unity/Assets/Editor/UnityBuildSettings.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Editor/UnityBuildSettings.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 8aad8237148ba44f28679965c7261205
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Editor/UnityBuildSettings.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Editor/UnityBuildSettings.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: 8aad8237148ba44f28679965c7261205
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterReceiver.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterReceiver.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 7b172109b462b004a88ce06b523925a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterReceiver.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterReceiver.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: 7b172109b462b004a88ce06b523925a5
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs
+++ b/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs
@@ -84,15 +84,11 @@ namespace FlutterUnityWidget
 #endif
         
         // iOS用のメッセージ送信
-#if UNITY_IOS && !UNITY_EDITOR
-        [DllImport("__Internal")]
-        private static extern void SendMessageToFlutterIOS(string message);
-#else
+        // 初期統合段階ではネイティブ連携が未設定でもビルドできるようスタブを使用
         private static void SendMessageToFlutterIOS(string message)
         {
             Debug.Log($"[iOS] Would send to Flutter: {message}");
         }
-#endif
         
         // テスト用メソッド
         public void SendTestMessage()

--- a/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs
+++ b/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs
@@ -84,11 +84,15 @@ namespace FlutterUnityWidget
 #endif
         
         // iOS用のメッセージ送信
-        // 初期統合段階ではネイティブ連携が未設定でもビルドできるようスタブを使用
+#if UNITY_IOS && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern void SendMessageToFlutterIOS(string message);
+#else
         private static void SendMessageToFlutterIOS(string message)
         {
             Debug.Log($"[iOS] Would send to Flutter: {message}");
         }
+#endif
         
         // テスト用メソッド
         public void SendTestMessage()

--- a/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: 8acf14457e0b38e48899fc8eb561b410
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Plugins/flutter_unity_widget/Runtime/FlutterUnityWidget.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 8acf14457e0b38e48899fc8eb561b410
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Scripts/FlutterReceiver.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Scripts/FlutterReceiver.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: 5b43ca2e7d7c9e34188c5421358d8ed9
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Scripts/FlutterReceiver.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Scripts/FlutterReceiver.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 5b43ca2e7d7c9e34188c5421358d8ed9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Scripts/SimpleTestScene.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Scripts/SimpleTestScene.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: eba6cac0af0106f4793af98c0e7065ac
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/Scripts/SimpleTestScene.cs.meta
+++ b/niigata-flower-guide-unity/Assets/Scripts/SimpleTestScene.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: eba6cac0af0106f4793af98c0e7065ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Assets/XR/Temp.meta
+++ b/niigata-flower-guide-unity/Assets/XR/Temp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a134197d3f0fc4ff7b5b72ae7e10b326
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/niigata-flower-guide-unity/Packages/manifest.json
+++ b/niigata-flower-guide-unity/Packages/manifest.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
-    "com.unity.xr.arfoundation": "5.1.1",
-    "com.unity.xr.arkit": "5.1.1",
+    "com.unity.multiplayer.center": "1.0.0",
+    "com.unity.xr.arkit": "6.1.1",
     "com.unity.xr.management": "4.5.1",
+    "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -33,8 +34,6 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0",
-    "com.unity.ugui": "1.0.0",
-    "com.unity.textmeshpro": "3.0.9"  
+    "com.unity.modules.xr": "1.0.0"
   }
 }

--- a/niigata-flower-guide-unity/Packages/manifest.json
+++ b/niigata-flower-guide-unity/Packages/manifest.json
@@ -1,9 +1,8 @@
 {
   "dependencies": {
-    "com.unity.multiplayer.center": "1.0.0",
-    "com.unity.xr.arkit": "6.1.1",
+    "com.unity.xr.arfoundation": "5.1.1",
+    "com.unity.xr.arkit": "5.1.1",
     "com.unity.xr.management": "4.5.1",
-    "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -34,6 +33,8 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.ugui": "1.0.0",
+    "com.unity.textmeshpro": "3.0.9"  
   }
 }

--- a/niigata-flower-guide-unity/Packages/packages-lock.json
+++ b/niigata-flower-guide-unity/Packages/packages-lock.json
@@ -9,7 +9,7 @@
     },
     "com.unity.inputsystem": {
       "version": "1.14.0",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.uielements": "1.0.0"
@@ -17,23 +17,24 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.3.2",
-      "depth": 2,
+      "version": "1.2.6",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.multiplayer.center": {
-      "version": "1.0.0",
+    "com.unity.textmeshpro": {
+      "version": "3.0.9",
       "depth": 0,
-      "source": "builtin",
+      "source": "registry",
       "dependencies": {
-        "com.unity.modules.uielements": "1.0.0"
-      }
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.ugui": {
-      "version": "2.0.0",
-      "depth": 2,
+      "version": "1.0.0",
+      "depth": 0,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
@@ -41,16 +42,16 @@
       }
     },
     "com.unity.xr.arfoundation": {
-      "version": "6.1.1",
-      "depth": 1,
+      "version": "5.1.1",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ugui": "2.0.0",
+        "com.unity.ugui": "1.0.0",
         "com.unity.modules.ui": "1.0.0",
-        "com.unity.inputsystem": "1.6.3",
-        "com.unity.mathematics": "1.2.6",
-        "com.unity.xr.core-utils": "2.5.1",
-        "com.unity.xr.management": "4.4.0",
+        "com.unity.inputsystem": "1.3.0",
+        "com.unity.mathematics": "1.2.5",
+        "com.unity.xr.core-utils": "2.2.1",
+        "com.unity.xr.management": "4.0.1",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0",
         "com.unity.modules.unityanalytics": "1.0.0",
@@ -59,13 +60,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.arkit": {
-      "version": "6.1.1",
+      "version": "5.1.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.xr.core-utils": "2.2.2",
-        "com.unity.xr.management": "4.4.0",
-        "com.unity.xr.arfoundation": "6.1.1",
+        "com.unity.xr.core-utils": "2.1.0",
+        "com.unity.xr.management": "4.0.1",
+        "com.unity.xr.arfoundation": "5.1.1",
         "com.unity.editorcoroutines": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -101,12 +102,6 @@
         "com.unity.xr.legacyinputhelpers": "2.1.11"
       },
       "url": "https://packages.unity.com"
-    },
-    "com.unity.modules.accessibility": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",
@@ -154,12 +149,6 @@
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.animation": "1.0.0"
       }
-    },
-    "com.unity.modules.hierarchycore": {
-      "version": "1.0.0",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {}
     },
     "com.unity.modules.imageconversion": {
       "version": "1.0.0",
@@ -249,8 +238,7 @@
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.hierarchycore": "1.0.0"
+        "com.unity.modules.jsonserialize": "1.0.0"
       }
     },
     "com.unity.modules.umbra": {

--- a/niigata-flower-guide-unity/Packages/packages-lock.json
+++ b/niigata-flower-guide-unity/Packages/packages-lock.json
@@ -9,7 +9,7 @@
     },
     "com.unity.inputsystem": {
       "version": "1.14.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.uielements": "1.0.0"
@@ -17,24 +17,23 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.2.6",
-      "depth": 1,
+      "version": "1.3.2",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "3.0.9",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.ugui": {
+    "com.unity.multiplayer.center": {
       "version": "1.0.0",
       "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      }
+    },
+    "com.unity.ugui": {
+      "version": "2.0.0",
+      "depth": 2,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
@@ -42,16 +41,16 @@
       }
     },
     "com.unity.xr.arfoundation": {
-      "version": "5.1.1",
-      "depth": 0,
+      "version": "6.1.1",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.ugui": "1.0.0",
+        "com.unity.ugui": "2.0.0",
         "com.unity.modules.ui": "1.0.0",
-        "com.unity.inputsystem": "1.3.0",
-        "com.unity.mathematics": "1.2.5",
-        "com.unity.xr.core-utils": "2.2.1",
-        "com.unity.xr.management": "4.0.1",
+        "com.unity.inputsystem": "1.6.3",
+        "com.unity.mathematics": "1.2.6",
+        "com.unity.xr.core-utils": "2.5.1",
+        "com.unity.xr.management": "4.4.0",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0",
         "com.unity.modules.unityanalytics": "1.0.0",
@@ -60,13 +59,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.arkit": {
-      "version": "5.1.1",
+      "version": "6.1.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.xr.core-utils": "2.1.0",
-        "com.unity.xr.management": "4.0.1",
-        "com.unity.xr.arfoundation": "5.1.1",
+        "com.unity.xr.core-utils": "2.2.2",
+        "com.unity.xr.management": "4.4.0",
+        "com.unity.xr.arfoundation": "6.1.1",
         "com.unity.editorcoroutines": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -102,6 +101,12 @@
         "com.unity.xr.legacyinputhelpers": "2.1.11"
       },
       "url": "https://packages.unity.com"
+    },
+    "com.unity.modules.accessibility": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {}
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",
@@ -149,6 +154,12 @@
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.animation": "1.0.0"
       }
+    },
+    "com.unity.modules.hierarchycore": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
     },
     "com.unity.modules.imageconversion": {
       "version": "1.0.0",
@@ -238,7 +249,8 @@
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.hierarchycore": "1.0.0"
       }
     },
     "com.unity.modules.umbra": {

--- a/niigata-flower-guide-unity/ProjectSettings/ProjectSettings.asset
+++ b/niigata-flower-guide-unity/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 28
+  serializedVersion: 26
   productGUID: f2f30904a4ae8a34e826862f56b7ae88
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -49,7 +49,6 @@ PlayerSettings:
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   unsupportedMSAAFallback: 0
-  m_SpriteBatchMaxVertexCount: 65535
   m_SpriteBatchVertexThreshold: 300
   m_MTRendering: 1
   mipStripping: 0
@@ -71,7 +70,7 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 1
   androidBlitType: 0
-  androidResizeableActivity: 1
+  androidResizableWindow: 0
   androidDefaultWindowWidth: 1920
   androidDefaultWindowHeight: 1080
   androidMinimumWindowWidth: 400
@@ -79,13 +78,14 @@ PlayerSettings:
   androidFullscreenMode: 1
   androidAutoRotationBehavior: 1
   androidPredictiveBackSupport: 1
-  androidApplicationEntry: 2
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 0
+  captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   Force IOS Speakers When Recording: 0
+  audioSpatialExperience: 0
   deferSystemGesturesMode: 0
   hideHomeButton: 0
   submitAnalytics: 1
@@ -98,7 +98,6 @@ PlayerSettings:
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 0
-  meshDeformation: 0
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0
   xboxEnableKinect: 0
@@ -130,8 +129,10 @@ PlayerSettings:
   switchAllowGpuScratchShrinking: 0
   switchNVNMaxPublicTextureIDCount: 0
   switchNVNMaxPublicSamplerIDCount: 0
-  switchMaxWorkerMultiple: 8
   switchNVNGraphicsFirmwareMemory: 32
+  switchMaxWorkerMultiple: 8
+  stadiaPresentMode: 0
+  stadiaTargetFramerate: 0
   vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
   vulkanEnablePreTransform: 0
@@ -161,7 +162,6 @@ PlayerSettings:
   resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.4
-  androidMinAspectRatio: 1
   applicationIdentifier:
     Android: com.example.niigata_flower_guide
     iPhone: com.example.niigataFlowerGuide
@@ -182,7 +182,7 @@ PlayerSettings:
   ForceInternetPermission: 0
   ForceSDCardPermission: 0
   CreateWallpaper: 0
-  androidSplitApplicationBinary: 0
+  APKExpansionFiles: 0
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
   strictShaderVariantMatching: 0
@@ -220,6 +220,7 @@ PlayerSettings:
     rgba: 0
   iOSLaunchScreenFillPct: 100
   iOSLaunchScreenSize: 100
+  iOSLaunchScreenCustomXibPath: 
   iOSLaunchScreeniPadType: 0
   iOSLaunchScreeniPadImage: {fileID: 0}
   iOSLaunchScreeniPadBackgroundColor:
@@ -227,6 +228,7 @@ PlayerSettings:
     rgba: 0
   iOSLaunchScreeniPadFillPct: 100
   iOSLaunchScreeniPadSize: 100
+  iOSLaunchScreeniPadCustomXibPath: 
   iOSLaunchScreenCustomStoryboardPath: 
   iOSLaunchScreeniPadCustomStoryboardPath: 
   iOSDeviceRequirements: []
@@ -263,12 +265,12 @@ PlayerSettings:
   useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 2
+  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
   AndroidKeyaliasName: 
   AndroidEnableArmv9SecurityFeatures: 0
-  AndroidEnableArm64MTE: 0
   AndroidBuildApkPerCpuArchitecture: 0
   AndroidTVCompatibility: 0
   AndroidIsGame: 1
@@ -281,41 +283,15 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  chromeosInputEmulation: 1
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 200
-  AndroidReportGooglePlayAppDependencies: 1
-  androidSymbolsSizeThreshold: 800
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:
-    - m_Textures: []
-      m_Width: 180
-      m_Height: 180
-      m_Kind: 0
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 120
-      m_Height: 120
-      m_Kind: 0
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 167
-      m_Height: 167
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 152
-      m_Height: 152
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 76
-      m_Height: 76
-      m_Kind: 0
-      m_SubKind: iPad
     - m_Textures: []
       m_Width: 120
       m_Height: 120
@@ -386,6 +362,31 @@ PlayerSettings:
       m_Height: 1024
       m_Kind: 4
       m_SubKind: App Store
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
   - m_BuildTarget: Android
     m_Icons:
     - m_Textures: []
@@ -507,7 +508,6 @@ PlayerSettings:
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
-  editorGfxJobOverride: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
@@ -660,7 +660,6 @@ PlayerSettings:
   switchEnableRamDiskSupport: 0
   switchMicroSleepForYieldTime: 25
   switchRamDiskSpaceSize: 12
-  switchUpgradedPlayerSettingsToNMETA: 0
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -764,11 +763,6 @@ PlayerSettings:
   webGLMemoryGeometricGrowthStep: 0.2
   webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
-  webGLWebAssemblyTable: 0
-  webGLWebAssemblyBigInt: 0
-  webGLCloseOnQuit: 0
-  webWasm2023: 0
-  webEnableSubmoduleStrippingCompatibility: 0
   scriptingDefineSymbols:
     iPhone: UNITY_XR_ARKIT_LOADER_ENABLED
   additionalCompilerArguments: {}
@@ -777,7 +771,6 @@ PlayerSettings:
     iPhone: 1
   il2cppCompilerConfiguration: {}
   il2cppCodeGeneration: {}
-  il2cppStacktraceInformation: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1
@@ -788,7 +781,6 @@ PlayerSettings:
   gcIncremental: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
-  editorAssembliesCompatibilityLevel: 1
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: niigata-flower-guide-unity
@@ -862,11 +854,9 @@ PlayerSettings:
   hmiPlayerDataPath: 
   hmiForceSRGBBlit: 0
   embeddedLinuxEnableGamepadInput: 0
-  hmiCpuConfiguration: 
   hmiLogStartupTiming: 0
-  qnxGraphicConfPath: 
+  hmiCpuConfiguration: 
   apiCompatibilityLevel: 6
-  captureStartupLogs: {}
   activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 89cda3f4-b4e2-46ba-b610-7217fdf03b16
@@ -880,6 +870,3 @@ PlayerSettings:
   platformRequiresReadableAssets: 0
   virtualTexturingSupportEnabled: 0
   insecureHttpOption: 0
-  androidVulkanDenyFilterList: []
-  androidVulkanAllowFilterList: []
-  androidVulkanDeviceFilterListAsset: {fileID: 0}

--- a/niigata-flower-guide-unity/ProjectSettings/ProjectSettings.asset
+++ b/niigata-flower-guide-unity/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 26
+  serializedVersion: 28
   productGUID: f2f30904a4ae8a34e826862f56b7ae88
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -49,6 +49,7 @@ PlayerSettings:
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   unsupportedMSAAFallback: 0
+  m_SpriteBatchMaxVertexCount: 65535
   m_SpriteBatchVertexThreshold: 300
   m_MTRendering: 1
   mipStripping: 0
@@ -70,7 +71,7 @@ PlayerSettings:
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 1
   androidBlitType: 0
-  androidResizableWindow: 0
+  androidResizeableActivity: 1
   androidDefaultWindowWidth: 1920
   androidDefaultWindowHeight: 1080
   androidMinimumWindowWidth: 400
@@ -78,14 +79,13 @@ PlayerSettings:
   androidFullscreenMode: 1
   androidAutoRotationBehavior: 1
   androidPredictiveBackSupport: 1
+  androidApplicationEntry: 2
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 0
-  captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   Force IOS Speakers When Recording: 0
-  audioSpatialExperience: 0
   deferSystemGesturesMode: 0
   hideHomeButton: 0
   submitAnalytics: 1
@@ -98,6 +98,7 @@ PlayerSettings:
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 0
+  meshDeformation: 0
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0
   xboxEnableKinect: 0
@@ -129,10 +130,8 @@ PlayerSettings:
   switchAllowGpuScratchShrinking: 0
   switchNVNMaxPublicTextureIDCount: 0
   switchNVNMaxPublicSamplerIDCount: 0
-  switchNVNGraphicsFirmwareMemory: 32
   switchMaxWorkerMultiple: 8
-  stadiaPresentMode: 0
-  stadiaTargetFramerate: 0
+  switchNVNGraphicsFirmwareMemory: 32
   vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
   vulkanEnablePreTransform: 0
@@ -162,6 +161,7 @@ PlayerSettings:
   resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.4
+  androidMinAspectRatio: 1
   applicationIdentifier:
     Android: com.example.niigata_flower_guide
     iPhone: com.example.niigataFlowerGuide
@@ -182,7 +182,7 @@ PlayerSettings:
   ForceInternetPermission: 0
   ForceSDCardPermission: 0
   CreateWallpaper: 0
-  APKExpansionFiles: 0
+  androidSplitApplicationBinary: 0
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
   strictShaderVariantMatching: 0
@@ -220,7 +220,6 @@ PlayerSettings:
     rgba: 0
   iOSLaunchScreenFillPct: 100
   iOSLaunchScreenSize: 100
-  iOSLaunchScreenCustomXibPath: 
   iOSLaunchScreeniPadType: 0
   iOSLaunchScreeniPadImage: {fileID: 0}
   iOSLaunchScreeniPadBackgroundColor:
@@ -228,7 +227,6 @@ PlayerSettings:
     rgba: 0
   iOSLaunchScreeniPadFillPct: 100
   iOSLaunchScreeniPadSize: 100
-  iOSLaunchScreeniPadCustomXibPath: 
   iOSLaunchScreenCustomStoryboardPath: 
   iOSLaunchScreeniPadCustomStoryboardPath: 
   iOSDeviceRequirements: []
@@ -265,12 +263,12 @@ PlayerSettings:
   useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 2
-  AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
   AndroidKeyaliasName: 
   AndroidEnableArmv9SecurityFeatures: 0
+  AndroidEnableArm64MTE: 0
   AndroidBuildApkPerCpuArchitecture: 0
   AndroidTVCompatibility: 0
   AndroidIsGame: 1
@@ -283,15 +281,41 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
-  chromeosInputEmulation: 1
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 200
+  AndroidReportGooglePlayAppDependencies: 1
+  androidSymbolsSizeThreshold: 800
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:
+    - m_Textures: []
+      m_Width: 180
+      m_Height: 180
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 120
+      m_Height: 120
+      m_Kind: 0
+      m_SubKind: iPhone
+    - m_Textures: []
+      m_Width: 167
+      m_Height: 167
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 152
+      m_Height: 152
+      m_Kind: 0
+      m_SubKind: iPad
+    - m_Textures: []
+      m_Width: 76
+      m_Height: 76
+      m_Kind: 0
+      m_SubKind: iPad
     - m_Textures: []
       m_Width: 120
       m_Height: 120
@@ -362,31 +386,6 @@ PlayerSettings:
       m_Height: 1024
       m_Kind: 4
       m_SubKind: App Store
-    - m_Textures: []
-      m_Width: 180
-      m_Height: 180
-      m_Kind: 0
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 120
-      m_Height: 120
-      m_Kind: 0
-      m_SubKind: iPhone
-    - m_Textures: []
-      m_Width: 167
-      m_Height: 167
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 152
-      m_Height: 152
-      m_Kind: 0
-      m_SubKind: iPad
-    - m_Textures: []
-      m_Width: 76
-      m_Height: 76
-      m_Kind: 0
-      m_SubKind: iPad
   - m_BuildTarget: Android
     m_Icons:
     - m_Textures: []
@@ -508,6 +507,7 @@ PlayerSettings:
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
+  editorGfxJobOverride: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
@@ -660,6 +660,7 @@ PlayerSettings:
   switchEnableRamDiskSupport: 0
   switchMicroSleepForYieldTime: 25
   switchRamDiskSpaceSize: 12
+  switchUpgradedPlayerSettingsToNMETA: 0
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -763,6 +764,11 @@ PlayerSettings:
   webGLMemoryGeometricGrowthStep: 0.2
   webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
+  webGLWebAssemblyTable: 0
+  webGLWebAssemblyBigInt: 0
+  webGLCloseOnQuit: 0
+  webWasm2023: 0
+  webEnableSubmoduleStrippingCompatibility: 0
   scriptingDefineSymbols:
     iPhone: UNITY_XR_ARKIT_LOADER_ENABLED
   additionalCompilerArguments: {}
@@ -771,6 +777,7 @@ PlayerSettings:
     iPhone: 1
   il2cppCompilerConfiguration: {}
   il2cppCodeGeneration: {}
+  il2cppStacktraceInformation: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1
@@ -781,6 +788,7 @@ PlayerSettings:
   gcIncremental: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
+  editorAssembliesCompatibilityLevel: 1
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: niigata-flower-guide-unity
@@ -854,9 +862,11 @@ PlayerSettings:
   hmiPlayerDataPath: 
   hmiForceSRGBBlit: 0
   embeddedLinuxEnableGamepadInput: 0
-  hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
+  hmiLogStartupTiming: 0
+  qnxGraphicConfPath: 
   apiCompatibilityLevel: 6
+  captureStartupLogs: {}
   activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 89cda3f4-b4e2-46ba-b610-7217fdf03b16
@@ -870,3 +880,6 @@ PlayerSettings:
   platformRequiresReadableAssets: 0
   virtualTexturingSupportEnabled: 0
   insecureHttpOption: 0
+  androidVulkanDenyFilterList: []
+  androidVulkanAllowFilterList: []
+  androidVulkanDeviceFilterListAsset: {fileID: 0}

--- a/niigata-flower-guide-unity/ProjectSettings/ProjectVersion.txt
+++ b/niigata-flower-guide-unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.1.5f1
-m_EditorVersionWithRevision: 6000.1.5f1 (923722cbbcfc)
+m_EditorVersion: 2022.3.62f1
+m_EditorVersionWithRevision: 2022.3.62f1 (4af31df58517)

--- a/niigata-flower-guide-unity/ProjectSettings/ProjectVersion.txt
+++ b/niigata-flower-guide-unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.62f1
-m_EditorVersionWithRevision: 2022.3.62f1 (4af31df58517)
+m_EditorVersion: 6000.1.5f1
+m_EditorVersionWithRevision: 6000.1.5f1 (923722cbbcfc)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,6 +272,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  gallery_saver:
+    dependency: "direct main"
+    description:
+      name: gallery_saver
+      sha256: df8b7e207ca12d64c71e0710a7ee3bc48aa7206d51cc720716fedb1543a66712
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   geoclue:
     dependency: transitive
     description:
@@ -404,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "0.13.6"
   http_parser:
     dependency: transitive
     description:
@@ -781,6 +789,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "0d55b1f1a31e5ad4c4967bfaa8ade0240b07d20ee4af1dfef5f531056512961a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "59e5a457ddcc1688f39e9aef0efb62aa845cf0cbbac47e44ac9730dc079a2385"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.13"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: f9a780aac57802b2892f93787e5ea53b5f43cc57dc107bee9436458365be71cd
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: cf2a1d29a284db648fd66cbd18aacc157f9862d77d2cc790f6f9678a46c1db5a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -267,6 +267,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_unity_widget:
+    dependency: "direct main"
+    description:
+      name: flutter_unity_widget
+      sha256: "91ed7166754f8c35358dfc92b8812d9ec5fbf1f6d67276a2462fda8ac6eef7f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2022.2.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -797,6 +805,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.1"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_web:
+    dependency: transitive
+    description:
+      name: webview_flutter_web
+      sha256: "18a7ccc1c31dd9a5c759a1b7217a2a1e04bd8f65712714a4070bfac19a23ca9e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3+4"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -267,14 +267,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_unity_widget:
-    dependency: "direct main"
-    description:
-      name: flutter_unity_widget
-      sha256: "91ed7166754f8c35358dfc92b8812d9ec5fbf1f6d67276a2462fda8ac6eef7f3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2022.2.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -805,46 +797,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  webview_flutter:
-    dependency: transitive
-    description:
-      name: webview_flutter
-      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.13.0"
-  webview_flutter_android:
-    dependency: transitive
-    description:
-      name: webview_flutter_android
-      sha256: "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.10.1"
-  webview_flutter_platform_interface:
-    dependency: transitive
-    description:
-      name: webview_flutter_platform_interface
-      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.14.0"
-  webview_flutter_web:
-    dependency: transitive
-    description:
-      name: webview_flutter_web
-      sha256: "18a7ccc1c31dd9a5c759a1b7217a2a1e04bd8f65712714a4070bfac19a23ca9e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.3+4"
-  webview_flutter_wkwebview:
-    dependency: transitive
-    description:
-      name: webview_flutter_wkwebview
-      sha256: fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.23.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   js: ^0.7.2
+  video_player: ^2.9.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -48,6 +49,7 @@ dependencies:
   url_launcher: ^6.2.2
   share_plus: ^11.1.0
   path_provider: ^2.1.5
+  gallery_saver: ^2.3.2
   # flutter_unity_widget: ^2022.2.0  # Unity連携を一旦保留
 
 dev_dependencies:
@@ -105,3 +107,5 @@ flutter:
 
   assets:
     - assets/images/
+    - assets/photos/
+    - assets/videos/

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,6 @@
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
-#include <flutter_unity_widget/flutter_unity_widget_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -21,8 +20,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
-  FlutterUnityWidgetPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterUnityWidgetPlugin"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_unity_widget/flutter_unity_widget_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -20,6 +21,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterUnityWidgetPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterUnityWidgetPlugin"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
   firebase_auth
   firebase_core
+  flutter_unity_widget
   geolocator_windows
   share_plus
   url_launcher_windows

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,7 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
   firebase_auth
   firebase_core
-  flutter_unity_widget
   geolocator_windows
   share_plus
   url_launcher_windows


### PR DESCRIPTION
### 概要
- **目的**: GitHub Pages（develop）でのデモスポット表示不具合を解消し、ビルドフラグでデモ/実スポットを切替。併せて AR 体験の追加、UI 調整、Unity 連携（iOS）の下地と安定運用のための一時無効化を反映。

### 含まれるコミット
- WIP: Flutter-Unity 連携（iOS）実装の下地を追加・調整（refs #40）
- Revert "WIP: Flutter-Unity 連携（iOS）実装の下地を追加・調整（refs #40）"
- chore: XR フォルダーの Temp メタファイルを追加して GUID を共有
- WIP: Flutter-Unity 連携（iOS）実装の下地を追加・調整（refs #40）
- chore(ios,flutter): 実機でのSNS共有検証のため Unity 連携を一時無効化し起動安定化
- feat(ar): 花プレビュー動画のモーダル再生を追加（選択UI＋保存ボタン対応）
- feat(ui): ホームのタイトル左寄せ＆サブタイトル追加、視覚ラインを統一
- feat: DEMOフラグでデモスポット/距離判定を切替可能に（GitHub Pages対応）

### 変更点
- **DEMO フラグ導入（GitHub Pages 対応）**
  - `--dart-define=DEMO=true|false` でデモ ON/OFF を切替
  - `lib/services/location_service.dart`: 判定を `spot.isDemo || _DemoConfig.demoMode` に統一、`kDebugMode` 依存を撤廃。デモ時は距離を常に 0m 扱い
  - `lib/providers/stamp_provider.dart`: 匿名認証/デモ処理を `DEMO` のみで制御（`kDebugMode` 依存を撤廃）
  - `lib/main.dart`: `DEMO=true` で偽装位置（新潟県中心）を常時有効化（Release でも有効）
  - `lib/screens/stamps_collection_screen.dart`: UI の `isDemo` フィルタを撤廃（表示は距離判定結果に依存）
  - `README.md`: DEMO ビルド手順と GitHub Actions 例を追記
- **AR 機能**: 花プレビュー動画のモーダル再生を追加（選択 UI＋保存ボタン対応）
- **UI 調整**: ホームのタイトル左寄せ、サブタイトル追加、視覚ラインを統一
- **Unity 連携（iOS）**
  - 下地を追加（WIP、refs #40）→ revert → 再適用と調整
  - 実機での SNS 共有検証を優先し、Unity 連携を一時無効化して起動安定化
  - XR フォルダーの Temp メタファイル追加で GUID 共有（衝突回避）

### 設定/デプロイ
- **develop（GitHub Pages）**
  - `.github/workflows/deploy-pages.yml` にて以下を指定済み
  ```yaml
  flutter build web --release \
    --dart-define=DEMO=true \
    --base-href "/${{ github.event.repository.name }}/"
  ```
  - `secrets.GOOGLE_MAPS_API_KEY` 必須
- **main（本番）**
  - 別ワークフローで `--dart-define=DEMO=false` を指定

### 動作確認
- **ローカル（Chrome）**
  ```bash
  flutter run -d chrome --dart-define=DEMO=true
  ```
  - デモスポットが表示され、距離 0m になること
- **GitHub Pages（develop）**
  - Actions のビルドログに `DEMO=true` が出力されること
  - デプロイ後、キャッシュクリアでデモスポット表示を確認
- **iOS 実機**
  - Unity 連携が無効化され、SNS 共有起動が安定していること
- **UI/AR**
  - ホームの文言/レイアウトが新仕様
  - 花プレビュー動画のモーダル再生・保存が動作

### 影響範囲
- スポット表示・距離判定・スタンプ取得、AR プレビュー、ホーム画面 UI、iOS 起動安定性（Unity 無効化中）

### リスク/ロールバック
- **リスク**: DEMO フラグの指定漏れで表示挙動が意図と異なる可能性
- **ロールバック**: 本 PR を revert、または `DEMO=false` で再ビルド

### 関連
- refs `#40`（Unity 連携 WIP）
- refs `#44`（機能ブランチ）