### PR TITLE
feat(day2): /api/plan 前処理 + Vertex連携(温度0) + フォールバック + Win対応

### DIFF
--- a/functions/data/spots.json
+++ b/functions/data/spots.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "s1",
+    "name": "新潟市中央公園",
+    "prefecture": "Niigata",
+    "lat": 37.9161,
+    "lng": 139.0364,
+    "tags": ["flower", "park"],
+    "seasons": ["spring", "summer"]
+  },
+  {
+    "id": "s2",
+    "name": "やすらぎ堤 桜並木",
+    "prefecture": "Niigata",
+    "lat": 37.9187,
+    "lng": 139.0421,
+    "tags": ["flower", "sakura"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s3",
+    "name": "福島潟 菜の花",
+    "prefecture": "Niigata",
+    "lat": 37.9455,
+    "lng": 139.2239,
+    "tags": ["flower", "nanohana"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s4",
+    "name": "弥彦公園 もみじ谷",
+    "prefecture": "Niigata",
+    "lat": 37.6889,
+    "lng": 138.8567,
+    "tags": ["poi", "maple"],
+    "seasons": ["autumn"]
+  },
+  {
+    "id": "s5",
+    "name": "国営越後丘陵公園",
+    "prefecture": "Niigata",
+    "lat": 37.4201,
+    "lng": 138.7963,
+    "tags": ["flower", "park", "tulip"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s6",
+    "name": "北方文化博物館 あじさい",
+    "prefecture": "Niigata",
+    "lat": 37.8672,
+    "lng": 139.1146,
+    "tags": ["flower", "ajisai"],
+    "seasons": ["rainy", "summer"]
+  },
+  {
+    "id": "s7",
+    "name": "上堰潟公園 菜の花",
+    "prefecture": "Niigata",
+    "lat": 37.7571,
+    "lng": 138.8809,
+    "tags": ["flower", "nanohana", "park"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s8",
+    "name": "長岡 東山ファミリーランド コスモス",
+    "prefecture": "Niigata",
+    "lat": 37.4488,
+    "lng": 138.8885,
+    "tags": ["flower", "cosmos"],
+    "seasons": ["autumn"]
+  },
+  {
+    "id": "s9",
+    "name": "月岡温泉 足湯",
+    "prefecture": "Niigata",
+    "lat": 37.8853,
+    "lng": 139.3335,
+    "tags": ["poi", "onsen"],
+    "seasons": ["all"]
+  },
+  {
+    "id": "s10",
+    "name": "瓢湖 白鳥見学",
+    "prefecture": "Niigata",
+    "lat": 37.8336,
+    "lng": 139.2409,
+    "tags": ["poi", "wildlife"],
+    "seasons": ["winter"]
+  }
+]
+
+

--- a/functions/src/data/spots.json
+++ b/functions/src/data/spots.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "s1",
+    "name": "新潟市中央公園",
+    "prefecture": "Niigata",
+    "lat": 37.9161,
+    "lng": 139.0364,
+    "tags": ["flower", "park"],
+    "seasons": ["spring", "summer"]
+  },
+  {
+    "id": "s2",
+    "name": "やすらぎ堤 桜並木",
+    "prefecture": "Niigata",
+    "lat": 37.9187,
+    "lng": 139.0421,
+    "tags": ["flower", "sakura"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s3",
+    "name": "福島潟 菜の花",
+    "prefecture": "Niigata",
+    "lat": 37.9455,
+    "lng": 139.2239,
+    "tags": ["flower", "nanohana"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s4",
+    "name": "弥彦公園 もみじ谷",
+    "prefecture": "Niigata",
+    "lat": 37.6889,
+    "lng": 138.8567,
+    "tags": ["poi", "maple"],
+    "seasons": ["autumn"]
+  },
+  {
+    "id": "s5",
+    "name": "国営越後丘陵公園",
+    "prefecture": "Niigata",
+    "lat": 37.4201,
+    "lng": 138.7963,
+    "tags": ["flower", "park", "tulip"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s6",
+    "name": "北方文化博物館 あじさい",
+    "prefecture": "Niigata",
+    "lat": 37.8672,
+    "lng": 139.1146,
+    "tags": ["flower", "ajisai"],
+    "seasons": ["rainy", "summer"]
+  },
+  {
+    "id": "s7",
+    "name": "上堰潟公園 菜の花",
+    "prefecture": "Niigata",
+    "lat": 37.7571,
+    "lng": 138.8809,
+    "tags": ["flower", "nanohana", "park"],
+    "seasons": ["spring"]
+  },
+  {
+    "id": "s8",
+    "name": "長岡 東山ファミリーランド コスモス",
+    "prefecture": "Niigata",
+    "lat": 37.4488,
+    "lng": 138.8885,
+    "tags": ["flower", "cosmos"],
+    "seasons": ["autumn"]
+  },
+  {
+    "id": "s9",
+    "name": "月岡温泉 足湯",
+    "prefecture": "Niigata",
+    "lat": 37.8853,
+    "lng": 139.3335,
+    "tags": ["poi", "onsen"],
+    "seasons": ["all"]
+  },
+  {
+    "id": "s10",
+    "name": "瓢湖 白鳥見学",
+    "prefecture": "Niigata",
+    "lat": 37.8336,
+    "lng": 139.2409,
+    "tags": ["poi", "wildlife"],
+    "seasons": ["winter"]
+  }
+]
+
+

--- a/functions/src/plan.ts
+++ b/functions/src/plan.ts
@@ -1,32 +1,153 @@
 import { onRequest } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
+import { buildPrompt, OUTPUT_SCHEMA } from "./prompt.js";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-export const plan = onRequest({ region: "asia-northeast1" }, async (req, res) => {
-  // CORS (開発用): Flutter Web dev サーバからのクロスオリジンを許可
-  const allowOrigin = "*"; // Day2以降、本番では限定推奨
-  res.setHeader("Access-Control-Allow-Origin", allowOrigin);
+// Optional: Vertex AI（環境が整っているときのみ使用）
+let maybeVertex: any = null;
+try {
+  // Lazy import to avoid emulator issues when credentials are missing
+  const mod = await import("@google-cloud/vertexai");
+  maybeVertex = mod;
+} catch {}
+
+type InputBody = {
+  origin?: { lat: number; lng: number };
+  durationHours?: number;
+  keywords?: string[];
+  includePoi?: boolean;
+};
+
+type Spot = {
+  id: string;
+  name: string;
+  prefecture: string;
+  lat: number;
+  lng: number;
+  tags: string[];
+  seasons: string[];
+};
+
+const REGION = process.env.FUNCTIONS_REGION || "asia-northeast1";
+const PROJECT_ID = process.env.GCP_PROJECT || process.env.GCLOUD_PROJECT || process.env.FIREBASE_CONFIG && (() => {
+  try { return JSON.parse(process.env.FIREBASE_CONFIG as string).projectId as string; } catch { return undefined; }
+})() || "";
+const VERTEX_MODEL = process.env.VERTEX_MODEL || "gemini-1.5-flash";
+const USE_VERTEX = process.env.USE_VERTEX === "1";
+
+function toRad(d: number) { return (d * Math.PI) / 180; }
+function haversineMeters(a: {lat:number;lng:number}, b: {lat:number;lng:number}) {
+  const R = 6371000;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const sa = Math.sin(dLat/2)**2 + Math.cos(toRad(a.lat))*Math.cos(toRad(b.lat))*Math.sin(dLng/2)**2;
+  return 2 * R * Math.asin(Math.sqrt(sa));
+}
+
+async function loadSpots(): Promise<Spot[]> {
+  // 実行時は lib/plan.js からの相対で ../data/spots.json を参照
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const primary = path.join(__dirname, "../data/spots.json");
+  try {
+    const json = await readFile(primary, "utf-8");
+    return JSON.parse(json) as Spot[];
+  } catch (e) {
+    // 開発中に src 配下を参照したいケースのフォールバック
+    const fallback = path.join(__dirname, "../src/data/spots.json");
+    const json = await readFile(fallback, "utf-8");
+    return JSON.parse(json) as Spot[];
+  }
+}
+
+function preprocess(spots: Spot[], origin: {lat:number;lng:number}, keywords: string[], includePoi: boolean): Spot[] {
+  let filtered = spots;
+  if (keywords && keywords.length > 0) {
+    const kw = new Set(keywords.map(k => k.toLowerCase()));
+    filtered = filtered.filter(s => s.tags.some(t => kw.has(t.toLowerCase())) || s.name && [...kw].some(k => s.name.toLowerCase().includes(k)));
+  }
+  if (!includePoi) {
+    filtered = filtered.filter(s => !s.tags.includes("poi"));
+  }
+  // 距離ソートし、上位をサブセットに
+  const withDist = filtered.map(s => ({ s, d: haversineMeters(origin, {lat:s.lat, lng:s.lng}) }));
+  withDist.sort((a,b) => a.d - b.d);
+  return withDist.slice(0, Math.min(30, withDist.length)).map(x => x.s);
+}
+
+function fallbackPlan(candidates: Spot[], origin: {lat:number;lng:number}, durationHours: number) {
+  const maxStops = Math.min(4, candidates.length);
+  const chosen = candidates.slice(0, maxStops);
+  const plan = chosen.map((c, idx) => ({
+    id: c.id,
+    startOffsetMin: idx * Math.floor((durationHours*60) / Math.max(1, maxStops)),
+    stayMin: 40,
+    reason: `距離が近く、季節(${c.seasons.join("/")})や体験価値（${c.tags.join(",")})が合致`
+  }));
+  return { plan, notes: "fallback" };
+}
+
+export const plan = onRequest({ region: REGION }, async (req, res) => {
+  // CORS (開発用)
+  res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") { res.status(204).send(""); return; }
+  if (req.method !== "POST") { res.status(405).json({ error: "Method Not Allowed" }); return; }
 
-  if (req.method === "OPTIONS") {
-    res.status(204).send("");
-    return;
-  }
-
-  if (req.method !== "POST") {
-    res.status(405).json({ error: "Method Not Allowed" });
-    return;
-  }
   try {
-    // Day1: Hello World 応答（固定JSON）。Day2でVertex呼び出しに置換
-    logger.info("/api/plan hello world");
-    res.status(200).json({
-      plan: [
-        { id: "s1", startOffsetMin: 0, stayMin: 40, reason: "雛形応答" },
-        { id: "s2", startOffsetMin: 50, stayMin: 40, reason: "雛形応答" }
-      ],
-      notes: "hello"
-    });
+    const body = (req.body || {}) as InputBody;
+    const origin = body.origin ?? { lat: 37.9161, lng: 139.0364 };
+    const durationHours = body.durationHours ?? 4;
+    const keywords = Array.isArray(body.keywords) ? body.keywords : [];
+    const includePoi = body.includePoi ?? true;
+
+    const spots = await loadSpots();
+    const subset = preprocess(spots, origin, keywords, includePoi);
+
+    // Vertex AI（有効時のみ）
+    if (USE_VERTEX && maybeVertex && PROJECT_ID) {
+      try {
+        const { VertexAI } = maybeVertex as any;
+        const vertex = new VertexAI({ project: PROJECT_ID, location: REGION });
+        const model = vertex.getGenerativeModel({ model: VERTEX_MODEL });
+        const prompt = buildPrompt({ origin, durationHours, keywords, includePoi, candidates: subset.map(s => ({ id:s.id, name:s.name, lat:s.lat, lng:s.lng, tags:s.tags, seasons:s.seasons })) });
+        const request = {
+          contents: [{ role: "user", parts: [{ text: prompt }] }],
+          generationConfig: {
+            responseMimeType: "application/json",
+            temperature: 0,
+            topP: 0,
+            topK: 1,
+            candidateCount: 1,
+            maxOutputTokens: 1024,
+          },
+        } as any;
+        const resp = await model.generateContent(request);
+        const text = resp?.response?.candidates?.[0]?.content?.parts?.[0]?.text || resp?.response?.text || "";
+        const parsed = JSON.parse(text);
+        if (parsed && Array.isArray(parsed.plan) && typeof parsed.notes === "string") {
+          // 安全化: stayMin等の型整形
+          parsed.plan = parsed.plan.map((it: any, idx: number) => ({
+            id: String(it.id ?? subset[idx % subset.length]?.id ?? `s${idx+1}`),
+            startOffsetMin: Number.isFinite(it.startOffsetMin) ? Math.floor(it.startOffsetMin) : idx * 45,
+            stayMin: Number.isFinite(it.stayMin) ? Math.floor(it.stayMin) : 40,
+            reason: String(it.reason ?? "AI提案")
+          }));
+          res.status(200).json(parsed);
+          return;
+        }
+        logger.warn("Vertex応答のJSON検証に失敗。フォールバックに切替");
+      } catch (ve: any) {
+        logger.warn(`Vertex呼び出し失敗。フォールバック使用: ${ve?.message || ve}`);
+      }
+    }
+
+    // フォールバック
+    const fb = fallbackPlan(subset, origin, durationHours);
+    res.status(200).json(fb);
   } catch (e: any) {
     res.status(500).json({ error: String(e?.message || e) });
   }

--- a/functions/src/prompt.ts
+++ b/functions/src/prompt.ts
@@ -12,4 +12,47 @@ export const OUTPUT_SCHEMA = {
 
 export const OUTPUT_SCHEMA_STR = JSON.stringify(OUTPUT_SCHEMA);
 
+export type MiniSpot = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  tags: string[];
+  seasons: string[];
+};
+
+export function buildPrompt(params: {
+  origin: { lat: number; lng: number };
+  durationHours: number;
+  keywords: string[];
+  includePoi: boolean;
+  candidates: MiniSpot[];
+}) {
+  const { origin, durationHours, keywords, includePoi, candidates } = params;
+  const candidatesJson = JSON.stringify(candidates);
+  const lines: string[] = [];
+  lines.push(
+    "あなたは新潟の観光・花スポットの旅程プランナーです。",
+    "次の制約を厳守してJSONのみを出力してください（説明文は禁止）。",
+    "- 出力は厳密に次のスキーマとすること: " + OUTPUT_SCHEMA_STR,
+    "- plan配列の要素数は3〜6件",
+    "- stayMinは各40〜90の範囲",
+    "- reasonには季節/距離/体験価値の観点を必ず含める",
+    "- 前後の説明文、コードブロック、余計な文字列は出力禁止（JSONのみ）",
+  );
+  lines.push("入力条件:");
+  lines.push(
+    JSON.stringify({
+      origin,
+      durationHours,
+      keywords,
+      includePoi,
+    })
+  );
+  lines.push("候補スポット（必要十分なサブセット）:");
+  lines.push(candidatesJson);
+  lines.push("これらを用いて上記スキーマのJSONのみ出力してください。");
+  return lines.join("\n");
+}
+
 


### PR DESCRIPTION
## 目的
- 固定入力で毎回同じ構造のJSONを返す /api/plan を構築（Vertex成功時も安定、失敗時は必ずフォールバック）

## 変更点
- functions/src/plan.ts:
  - CORS + OPTIONS
  - 前処理（距離ソート→サブセット化）
  - Vertex連携（temperature=0, topP=0, topK=1, candidateCount=1, maxOutputTokens=1024）
  - JSON整形（型/順序の安定化）
  - フォールバック生成
  - Windowsパス解決の安定化(fileURLToPath)
- functions/src/prompt.ts: 出力スキーマ/プロンプト生成
- functions/(src|)/data/spots.json: データ追加

## 動作確認
- USE_VERTEX=1 + GOOGLE_APPLICATION_CREDENTIALS=... でVertex成功、未設定時はフォールバックで常にJSON返却
- 同一入力2回の比較で同一（PowerShell/Flutter）

## セキュリティ
- サービスアカウント鍵(JSON)はリポジトリ外で管理（コミットしない）

## 次（Day3）
- Flutter: 行程カード表示、Directions(Polyline/JS)、ローディング/リトライ、前回成功キャッシュ