### PR TITLE
Day3: Flutter統合（カード/ポリライン/自動ズーム/キャッシュ）MVP完成

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../services/plan_api.dart';
 import '../data/spot.dart';
 import '../data/spot_repository.dart';
@@ -30,11 +31,14 @@ class _HomePageState extends State<HomePage> {
 
   final Completer<GoogleMapController> mapController = Completer();
   final Set<Marker> markers = {};
+  final Set<Polyline> polylines = {};
+  List<LatLng> _lastRoute = const [];
 
   @override
   void initState() {
     super.initState();
     _loadSpots();
+    _loadCache();
   }
 
   Future<void> _loadSpots() async {
@@ -76,6 +80,8 @@ class _HomePageState extends State<HomePage> {
         includePoi: includePoi,
       ));
       setState(() => lastPlan = res);
+      await _saveCache(res);
+      _updatePolyline();
     } catch (e) {
       setState(() => error = '$e');
     } finally {
@@ -83,11 +89,93 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  Future<void> _saveCache(Map<String, dynamic> plan) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('last_plan_json', jsonEncode(plan));
+  }
+
+  Future<void> _loadCache() async {
+    final prefs = await SharedPreferences.getInstance();
+    final s = prefs.getString('last_plan_json');
+    if (s != null) {
+      try {
+        final cached = jsonDecode(s) as Map<String, dynamic>;
+        setState(() => lastPlan = cached);
+        _updatePolyline();
+      } catch (_) {}
+    }
+  }
+
+  void _updatePolyline() {
+    if (lastPlan == null || spots.isEmpty) return;
+    final planList = (lastPlan!['plan'] as List?)?.cast<dynamic>() ?? [];
+    final idToSpot = {for (final s in spots) s.id: s};
+    final coords = <LatLng>[];
+    for (final item in planList) {
+      final id = (item as Map<String, dynamic>)['id'] as String?;
+      if (id == null) continue;
+      final s = idToSpot[id];
+      if (s != null) {
+        coords.add(LatLng(s.lat, s.lng));
+      }
+    }
+    setState(() {
+      polylines.clear();
+      if (coords.length >= 2) {
+        polylines.add(Polyline(
+          polylineId: const PolylineId('route'),
+          points: coords,
+          color: Colors.blue,
+          width: 4,
+        ));
+        _lastRoute = List<LatLng>.from(coords);
+      }
+    });
+    if (coords.length >= 2) {
+      _fitToPolyline(coords);
+    }
+  }
+
+  Future<void> _fitToPolyline(List<LatLng> coords) async {
+    if (!mapController.isCompleted) return;
+    final ctrl = await mapController.future;
+    double minLat = coords.first.latitude;
+    double maxLat = coords.first.latitude;
+    double minLng = coords.first.longitude;
+    double maxLng = coords.first.longitude;
+    for (final p in coords) {
+      if (p.latitude < minLat) minLat = p.latitude;
+      if (p.latitude > maxLat) maxLat = p.latitude;
+      if (p.longitude < minLng) minLng = p.longitude;
+      if (p.longitude > maxLng) maxLng = p.longitude;
+    }
+    final bounds = LatLngBounds(
+      southwest: LatLng(minLat, minLng),
+      northeast: LatLng(maxLat, maxLng),
+    );
+    try {
+      await ctrl.animateCamera(CameraUpdate.newLatLngBounds(bounds, 48));
+    } catch (_) {
+      // Webで例外になる場合は中心へ移動
+      final center = LatLng((minLat + maxLat) / 2, (minLng + maxLng) / 2);
+      await ctrl.animateCamera(CameraUpdate.newLatLngZoom(center, 11));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final latLng = LatLng(37.9161, 139.0364);
     return Scaffold(
-      appBar: AppBar(title: const Text('ハッカソンMVP')),
+      appBar: AppBar(
+        title: const Text('ハッカソンMVP'),
+        actions: [
+          IconButton(
+            tooltip: 'ルートにズーム',
+            onPressed: _lastRoute.length >= 2 ? () => _fitToPolyline(_lastRoute) : null,
+            icon: const Icon(Icons.route),
+          ),
+        ],
+      ),
       body: Row(
         children: [
           Expanded(
@@ -127,12 +215,28 @@ class _HomePageState extends State<HomePage> {
                       padding: EdgeInsets.symmetric(vertical: 12),
                       child: LinearProgressIndicator(),
                     ),
-                    if (error != null) Text(error!, style: const TextStyle(color: Colors.red)),
+                    if (error != null)
+                      Row(
+                        children: [
+                          Expanded(child: Text(error!, style: const TextStyle(color: Colors.red))),
+                          TextButton(onPressed: loading ? null : _submit, child: const Text('再試行')),
+                        ],
+                      ),
                     const SizedBox(height: 12),
                     if (lastPlan != null) ...[
                       const Text('提案結果', style: TextStyle(fontWeight: FontWeight.bold)),
                       const SizedBox(height: 8),
-                      Text(JsonEncoder.withIndent('  ').convert(lastPlan)),
+                      _PlanCards(plan: lastPlan!, spots: spots),
+                      const SizedBox(height: 8),
+                      ExpansionTile(
+                        title: const Text('RAW JSON'),
+                        children: [
+                          SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: Text(JsonEncoder.withIndent('  ').convert(lastPlan)),
+                          ),
+                        ],
+                      ),
                     ],
                   ],
                 ),
@@ -144,10 +248,72 @@ class _HomePageState extends State<HomePage> {
             child: GoogleMap(
               initialCameraPosition: CameraPosition(target: latLng, zoom: 11),
               markers: markers,
+              polylines: polylines,
               onMapCreated: (c) => mapController.complete(c),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+
+class _PlanCards extends StatelessWidget {
+  final Map<String, dynamic> plan;
+  final List<Spot> spots;
+  const _PlanCards({required this.plan, required this.spots});
+
+  @override
+  Widget build(BuildContext context) {
+    final idToSpot = {for (final s in spots) s.id: s};
+    final items = (plan['plan'] as List?)?.cast<dynamic>() ?? const [];
+    if (items.isEmpty) return const Text('提案がありません');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int i = 0; i < items.length; i++) ...[
+          _PlanCardItem(index: i + 1, item: items[i] as Map<String, dynamic>, idToSpot: idToSpot),
+          const SizedBox(height: 8),
+        ]
+      ],
+    );
+  }
+}
+
+class _PlanCardItem extends StatelessWidget {
+  final int index;
+  final Map<String, dynamic> item;
+  final Map<String, Spot> idToSpot;
+  const _PlanCardItem({required this.index, required this.item, required this.idToSpot});
+
+  @override
+  Widget build(BuildContext context) {
+    final id = item['id'] as String? ?? '';
+    final s = idToSpot[id];
+    final title = s?.name ?? id;
+    final stay = item['stayMin'] as int? ?? 40;
+    final reason = item['reason'] as String? ?? '';
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(radius: 12, child: Text('$index')),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+                ),
+                Text('$stay 分'),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(reason),
+          ],
+        ),
       ),
     );
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import geolocator_apple
 import package_info_plus
 import path_provider_foundation
 import share_plus
+import shared_preferences_foundation
 import url_launcher_macos
 import video_player_avfoundation
 
@@ -25,6 +26,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -640,6 +640,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.12"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   share_plus: ^11.1.0
   path_provider: ^2.1.5
   gallery_saver: ^2.3.2
+  shared_preferences: ^2.3.3
   # flutter_unity_widget: ^2022.2.0  # Unity連携を一旦保留
 
 dev_dependencies:


### PR DESCRIPTION
## 概要
- 1画面で「入力 → AI提案(JSON) → 地図ルート表示」まで再現（DoD達成）

## 変更点
- UI: 提案カード、直線ポリライン、ズームフィット、エラー/再試行
- 永続化: SharedPreferencesで前回成功結果をキャッシュ
- 依存: shared_preferences を追加

## 動作確認
1) エミュ起動（Functions/Hosting）
2) Web（またはiOS）起動 → 入力＆AIにおまかせ
3) カード表示、直線ルート、地図の自動ズームを確認
4) 再起動後も前回結果が復元されること

## 次（Day4）
- spots.json を50〜100件へ拡充
- プロンプト強化（季節/距離/体験価値の理由必須）
- コスト最適化（候補圧縮/Directions呼び出し最小化）
- Webプレビュー（Firebase Hosting preview: hackathon-2025）