### PR TITLE
fix: Google Maps のキー注入を meta 方式へ統一（ApiTargetBlockedMapError を解消）

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -32,7 +32,8 @@ jobs:
           flutter build web --release -t lib/hackathon/main_hackathon.dart
 
       - name: Inject Google Maps API key
-        run: sed -i 's/MAPS_API_KEY/${{ secrets.HACKATHON_MAPS_API_KEY }}/g' build/web/index.html
+        run: sed -i 's/<meta name="google_maps_api_key" content="MAPS_API_KEY">/<meta name="google_maps_api_key" content="${{ secrets.HACKATHON_MAPS_API_KEY }}">/g' build/web/index.html
+
 
       - name: Deploy to Firebase Hosting (preview channel)
         run: |

--- a/web/index.html
+++ b/web/index.html
@@ -24,11 +24,12 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="niigata_flower_guide">
+  <meta name="google_maps_api_key" content="MAPS_API_KEY" />
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Google Maps JavaScript API (Web用APIキーを必ず設定) -->
   <!-- 本番用: GitHub Secrets経由で安全に注入 -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=MAPS_API_KEY"></script>
+  <!-- <script src="https://maps.googleapis.com/maps/api/js?key=MAPS_API_KEY"></script> -->
 
   <!-- Firebase JavaScript SDK -->
   <script type="module">


### PR DESCRIPTION
### 背景
Firebase Hosting のプレビューURL（*.web.app）で Map が表示されず、
コンソールに `ApiTargetBlockedMapError` が出ていました。
google_maps_flutter_web の自動ロードと、index.html の手動ロードが混在していたため、
API制限と読み込み順の不整合が発生していた可能性があります。

### 変更点
- web/index.html:
  - `<meta name="google_maps_api_key" content="MAPS_API_KEY">` を追加
  - 手動の `<script src="https://maps.googleapis.com/maps/api/js?...">` を削除
- .github/workflows/firebase-hosting.yml:
  - `sed` により **meta の content** 内の `MAPS_API_KEY` を
    `${{ secrets.HACKATHON_MAPS_API_KEY }}` に置換するよう修正

### 期待される効果
- google_maps_flutter_web が内部で Maps JS を適切にロード
- `maps/api/js?...key=xxxx` が 200 で取得され、Map が表示される
- `ApiTargetBlockedMapError` の解消
- スクリプト重複読み込みや非同期順序依存の回避

### 動作確認
1. CI のプレビューURLにデプロイ
2. DevTools > Network で `maps/api/js` リクエストが **Status: 200** で1本だけ出ることを確認
3. 画面に地図が表示されることを確認
4. コンソールにエラーが出ないこと（※ async 警告は対象外）

### 環境・設定
- GitHub Secrets:
  - `HACKATHON_MAPS_API_KEY`（必須）
  - `FIREBASE_PROJECT_ID`, `FIREBASE_TOKEN`
- GCP 側の API キー制限（推奨）
  - リファラー: `https://*.web.app/*`, `https://*.firebaseapp.com/*`, `http://localhost:*/*`, `http://127.0.0.1:*/*`
  - API: **Maps JavaScript API**（＋必要に応じて Places(Directions/Geocoding 等)）

### 影響範囲
- Web ビルド/デプロイのみ。モバイルには影響なし。

### リスク・ロールバック
- もし問題があれば、このPRをリバートし、以前の `<script>` 方式に戻せます。
