### PR TITLE
Day5: WebのGoogleMap灰画面対策（レイアウト安定化）

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -179,7 +179,9 @@ class _HomePageState extends State<HomePage> {
           ),
         ],
       ),
-      body: Row(
+      body: SafeArea(
+        child: SizedBox.expand(
+          child: Row(
         children: [
           Expanded(
             flex: 2,
@@ -252,10 +254,14 @@ class _HomePageState extends State<HomePage> {
               initialCameraPosition: CameraPosition(target: latLng, zoom: 11),
               markers: markers,
               polylines: polylines,
+              zoomControlsEnabled: false,
+              myLocationButtonEnabled: false,
               onMapCreated: (c) => mapController.complete(c),
             ),
           ),
         ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 目的
- WebプレビューでGoogleMapが灰色になる問題のレイアウト起因を解消

## 変更点
- lib/ui/home_page.dart
  - Scaffold.bodyをSafeArea+SizedBox.expandでラップし、Row/Expanded構成の高さを確保
  - GoogleMapの余計なコントロールを無効化（描画干渉の最小化）
  - 既存のAPI呼び出し分岐（Web=相対 /api/plan, ローカル=エミュ直POST）を維持

## 動作確認
- プレビューURLをシークレットウィンドウで開く（SW/キャッシュ回避）
- 地図が表示され、提案後にポリラインが描画されること
- もし引き続き灰表示の場合は、一時的に `SizedBox(height: 520, child: GoogleMap(...))` で固定し切り分け

## 影響範囲
- 画面レイアウトのみ（機能/APIには変更なし）

## 追記（次対応候補）
- Map Tiles(API)の200応答確認
- 必要に応じて固定高さ/Stack配置への切替を検討