### PR TITLE
CI/WEB: Google Maps読み込みを確実化（script方式＋Secrets注入検証）/ ハッカソン版ビルド維持

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Inject Google Maps API key
         run: |
           sed -i "s/MAPS_API_KEY/${{ secrets.HACKATHON_MAPS_API_KEY }}/g" build/web/index.html
-          grep -n 'google_maps_api_key' build/web/index.html || (echo "meta tag not found" && exit 1)
+          if grep -q 'MAPS_API_KEY' build/web/index.html; then echo "token not replaced"; exit 1; fi
 
 
       - name: Deploy to Firebase Hosting (preview channel)

--- a/web/index.html
+++ b/web/index.html
@@ -27,9 +27,8 @@
   <meta name="google_maps_api_key" content="MAPS_API_KEY" />
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
-  <!-- Google Maps JavaScript API (Web用APIキーを必ず設定) -->
-  <!-- 本番用: GitHub Secrets経由で安全に注入 -->
-  <!-- <script src="https://maps.googleapis.com/maps/api/js?key=MAPS_API_KEY"></script> -->
+  <!-- Google Maps JavaScript API (CIでMAPS_API_KEYを注入) -->
+  <script src="https://maps.googleapis.com/maps/api/js?key=MAPS_API_KEY"></script>
 
   <!-- Firebase JavaScript SDK -->
   <script type="module">


### PR DESCRIPTION
## 背景
- metaタグ形状差で置換が不安定 → JS SDKが読み込まれずNetworkにmaps/api/jsが出ないケース
- script方式に戻し、Secrets注入の検証も強化して確実にロード

## 変更点
- web/index.html: <script src="https://maps.googleapis.com/maps/api/js?key=MAPS_API_KEY"> を復帰（metaは残置）
- .github/workflows/firebase-hosting.yml:
  - sedでMAPS_API_KEY → ${{ secrets.HACKATHON_MAPS_API_KEY }} に置換
  - 置換確認: 残存トークンがあればexit 1で検知
  - ビルドは --target=lib/hackathon/main_hackathon.dart を維持

## 動作確認
- hackathon-2025へpush / Run workflow
- プレビューURL（シークレット/ハードリロード）で:
  - Networkに maps.googleapis.com/maps/api/js?...key=... が200
  - maptiles.googleapis.com/... も200
  - 地図描画OK、AI提案→ポリライン表示

## 影響範囲
- CI/デプロイとWebエントリのみ。アプリ機能への影響はなし